### PR TITLE
fix: Update Claude Code action to @beta tag

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v0.1.1
+        uses: anthropics/claude-code-action@beta
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/test-claude-bot.yml
+++ b/.github/workflows/test-claude-bot.yml
@@ -65,7 +65,7 @@ Claude should respond to this issue if properly configured.
       
       - name: Test Claude Action Directly
         if: steps.check-key.outputs.has_key == 'true'
-        uses: anthropics/claude-code-action@v0.1.1
+        uses: anthropics/claude-code-action@beta
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Fixed Claude bot version in two workflows that were using non-existent v0.1.1
- Updated to use @beta tag which is proven to work

## Problem
PR #19 didn't trigger the Claude bot review because the workflows were referencing a non-existent version (v0.1.1) of the Claude Code action.

## Solution
Updated both workflows to use the @beta tag, matching the main claude.yml workflow that already works correctly.

## Testing
The Claude bot should now properly review this PR and future PRs automatically.

🤖 Generated with [Claude Code](https://claude.ai/code)