### PR TITLE
feat: Add 8 default templates for v1.3.0 (Part 3/5)

### DIFF
--- a/library/templates/code-documentation.md
+++ b/library/templates/code-documentation.md
@@ -4,7 +4,7 @@ description: Technical documentation template for code modules, APIs, and functi
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - documentation

--- a/library/templates/email-professional.md
+++ b/library/templates/email-professional.md
@@ -4,7 +4,7 @@ description: Business email template with proper formatting and tone
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - email

--- a/library/templates/meeting-notes.md
+++ b/library/templates/meeting-notes.md
@@ -4,7 +4,7 @@ description: Structured template for capturing and organizing meeting informatio
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - meeting

--- a/library/templates/penetration-test-report.md
+++ b/library/templates/penetration-test-report.md
@@ -6,7 +6,7 @@ description: >-
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - penetration-testing

--- a/library/templates/project-brief.md
+++ b/library/templates/project-brief.md
@@ -4,7 +4,7 @@ description: Comprehensive project overview template for planning and communicat
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - project

--- a/library/templates/project-proposal.md
+++ b/library/templates/project-proposal.md
@@ -4,7 +4,7 @@ description: Professional template for creating comprehensive project proposals
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-15'
+created_date: '2025-07-15'
 unique_id: template_project-proposal_dollhousemcp_20250715-100300
 category: professional
 tags:

--- a/library/templates/report-executive.md
+++ b/library/templates/report-executive.md
@@ -6,7 +6,7 @@ description: >-
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - report

--- a/library/templates/security-vulnerability-report.md
+++ b/library/templates/security-vulnerability-report.md
@@ -6,7 +6,7 @@ description: >-
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - vulnerability

--- a/library/templates/threat-assessment-report.md
+++ b/library/templates/threat-assessment-report.md
@@ -6,7 +6,7 @@ description: >-
 type: template
 version: 1.0.0
 author: dollhousemcp
-created: '2025-07-23'
+created_date: '2025-07-23'
 category: professional
 tags:
   - threat-modeling


### PR DESCRIPTION
## Summary
This PR adds 8 default templates to the collection as part of the v1.3.0 release.

## Context
This is part 3 of 5 PRs splitting up the large PR #73 into smaller, reviewable chunks.

## What's Added

### 📄 Templates (8)
- `code-documentation` - Technical documentation structure
- `email-professional` - Professional email formats
- `meeting-notes` - Meeting documentation template
- `penetration-test-report` - Security test reporting
- `project-brief` - Project overview template
- `report-executive` - Executive summary format
- `security-vulnerability-report` - Security findings report
- `threat-assessment-report` - Threat analysis documentation

## Testing
All validation passes for these templates with the updated schemas.

## Related
- Original PR: #73
- Previous PRs: #79 (Personas), #80 (Skills)
- Next PR will add: Agents and Memories (5 files)

@claude please review this PR