### PR TITLE
feat: Enable Claude to create PR approvals for branch protection

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -92,6 +92,80 @@ jobs:
             
             Be constructive and helpful. Consider this is a collection platform for AI content.
 
+      - name: Create PR Review
+        if: steps.claude-review.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Wait a moment to ensure Claude's comments are posted
+            await new Promise(resolve => setTimeout(resolve, 3000));
+            
+            // Get all comments on the PR
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+            
+            // Find Claude's review comment (most recent)
+            const claudeComment = comments.data
+              .filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Claude'))
+              .pop();
+            
+            // Analyze Claude's feedback for critical issues
+            let reviewEvent = 'APPROVE';
+            let reviewBody = '✅ **Automated Review Complete**\n\n';
+            
+            if (claudeComment) {
+              const feedback = claudeComment.body.toLowerCase();
+              
+              // Check for blocking issues in Claude's feedback
+              const hasBlockingIssues = 
+                feedback.includes('security') && (feedback.includes('vulnerability') || feedback.includes('risk')) ||
+                feedback.includes('critical') ||
+                feedback.includes('must fix') ||
+                feedback.includes('blocking') ||
+                feedback.includes('dangerous');
+              
+              const hasSuggestions = 
+                feedback.includes('consider') ||
+                feedback.includes('suggest') ||
+                feedback.includes('could') ||
+                feedback.includes('minor');
+              
+              if (hasBlockingIssues) {
+                reviewEvent = 'REQUEST_CHANGES';
+                reviewBody = '❌ **Changes Requested**\n\nClaude has identified issues that should be addressed. Please review the feedback above.';
+              } else if (hasSuggestions) {
+                reviewEvent = 'APPROVE';
+                reviewBody = '✅ **Approved with Suggestions**\n\nClaude has approved this PR with some non-blocking suggestions. See the feedback above.';
+              } else {
+                reviewBody = '✅ **Approved**\n\nClaude has reviewed this PR and found no issues.';
+              }
+            }
+            
+            // Create the review
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                body: reviewBody,
+                event: reviewEvent
+              });
+              console.log(`${reviewEvent === 'APPROVE' ? '✅' : '❌'} PR review created: ${reviewEvent}`);
+            } catch (error) {
+              console.error('Failed to create review:', error);
+              // Fallback to comment if review creation fails
+              await github.rest.issues.createComment({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '✅ Claude review completed. (Note: Automated approval failed, manual approval may be required)'
+              });
+            }
+
       - name: Handle Claude API Failure
         if: steps.claude-review.outcome == 'failure'
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

This PR adds the ability for Claude to create actual GitHub PR reviews (not just comments), allowing it to satisfy branch protection requirements.

## Problem
- Currently, Claude only posts comments which don't count as reviews
- Single-maintainer repos can't use branch protection effectively
- No automated way to get required PR approvals

## Solution
- Added a new step to create GitHub PR reviews after Claude's analysis
- Claude can now:
  - **APPROVE** PRs when no blocking issues found
  - **REQUEST_CHANGES** when critical/security issues detected
  - Analyze its own feedback to make intelligent decisions

## How it Works
1. Claude reviews the PR and posts detailed feedback (existing behavior)
2. New step analyzes Claude's feedback for keywords indicating issues
3. Creates appropriate GitHub review based on analysis:
   - Blocking keywords (security, critical, dangerous) → REQUEST_CHANGES
   - Suggestions only → APPROVE with note
   - No issues → APPROVE

## Benefits
- Enables branch protection for single-maintainer repos
- Claude reviews now count as legitimate PR approvals
- Maintains safety by requesting changes for critical issues
- Fallback to comments if review creation fails

## Testing
- This PR only modifies the Claude review workflow
- Claude should review and approve this PR (meta\!)
- No other files are changed

## Related
- Implements automated review approval capability for single-maintainer workflow efficiency
- Clean PR with only the intended changes (unlike #84)