### PR TITLE
feat: Add 7 default skills for v1.3.0 (skills only)

### DIFF
--- a/library/skills/coding/code-review.md
+++ b/library/skills/coding/code-review.md
@@ -1,0 +1,130 @@
+---
+name: Code Review
+description: Systematic code analysis for quality, security, and best practices
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: professional
+tags:
+  - code-quality
+  - security
+  - best-practices
+  - review
+proficiency_levels:
+  beginner: Basic syntax and style checking
+  intermediate: Design patterns and architecture review
+  advanced: Security vulnerabilities and performance optimization
+parameters:
+  language:
+    type: string
+    description: Programming language to review
+    required: false
+    default: auto-detect
+  focus_areas:
+    type: array
+    description: Specific areas to focus on
+    default:
+      - security
+      - performance
+      - maintainability
+      - testing
+  severity_threshold:
+    type: string
+    description: Minimum severity to report
+    default: info
+    enum:
+      - error
+      - warning
+      - info
+      - style
+unique_id: skill_code-review_dollhousemcp_20250723-165719
+capabilities:
+  - code-quality
+  - security
+  - best-practices
+  - review
+---
+
+# Code Review Skill
+
+This skill provides systematic code analysis capabilities for identifying issues, suggesting improvements, and ensuring code quality.
+
+## Core Capabilities
+
+### 1. Security Analysis
+- SQL injection vulnerabilities
+- XSS and CSRF risks
+- Authentication/authorization flaws
+- Sensitive data exposure
+- Dependency vulnerabilities
+
+### 2. Code Quality
+- SOLID principles adherence
+- Design pattern usage
+- Code duplication detection
+- Complexity analysis
+- Naming conventions
+
+### 3. Performance Review
+- Algorithm efficiency
+- Database query optimization
+- Memory usage patterns
+- Caching opportunities
+- Async/await patterns
+
+### 4. Best Practices
+- Error handling patterns
+- Logging practices
+- Documentation completeness
+- Test coverage analysis
+- Configuration management
+
+## Review Process
+
+### Step 1: Initial Scan
+Quick overview identifying:
+- Language and framework
+- Project structure
+- Key dependencies
+- Test presence
+
+### Step 2: Deep Analysis
+Detailed examination of:
+- Critical paths
+- Security boundaries
+- Data flow
+- Error scenarios
+
+### Step 3: Recommendations
+Prioritized suggestions for:
+- Critical fixes (security/bugs)
+- Important improvements
+- Nice-to-have enhancements
+- Future considerations
+
+## Output Format
+
+Reviews are structured as:
+1. **Executive Summary** - High-level findings
+2. **Critical Issues** - Must-fix problems
+3. **Recommendations** - Suggested improvements
+4. **Positive Findings** - What's done well
+5. **Metrics** - Code quality scores
+
+## Example Usage
+
+When activated, this skill enhances the AI's ability to:
+- Spot subtle bugs and vulnerabilities
+- Suggest idiomatic improvements
+- Identify performance bottlenecks
+- Recommend testing strategies
+- Ensure security best practices
+
+## Integration Notes
+
+This skill works well with:
+- Debug Detective persona for deep debugging
+- Technical Analyst persona for architecture review
+- Security-focused agents for vulnerability scanning
+- Documentation templates for review reports

--- a/library/skills/coding/debugging-assistant.md
+++ b/library/skills/coding/debugging-assistant.md
@@ -1,19 +1,25 @@
 ---
 type: skill
 name: Debugging Assistant
-description: A specialized skill for helping debug code across multiple programming languages
-unique_id: debugging-assistant_20250715-100000_dollhousemcp
-author: dollhousemcp
+description: >-
+  A specialized skill for helping debug code across multiple programming
+  languages
+unique_id: skill_debugging-assistant_dollhousemcp_20250715-100000
+author: DollhouseMCP
 category: professional
 version: 1.0.0
-created_date: 2025-07-15
-tags: [debugging, programming, troubleshooting, code-analysis]
+tags:
+  - debugging
+  - programming
+  - troubleshooting
+  - code-analysis
 license: MIT
 capabilities:
   - error_analysis
   - code_review
   - debugging_strategies
   - multi_language_support
+created: 2025-07-15T00:00:00.000Z
 ---
 
 # Debugging Assistant Skill

--- a/library/skills/creative/creative-writing.md
+++ b/library/skills/creative/creative-writing.md
@@ -1,0 +1,214 @@
+---
+name: Creative Writing
+description: Storytelling, narrative construction, and creative content generation
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: creative
+tags:
+  - writing
+  - storytelling
+  - creativity
+  - narrative
+  - fiction
+proficiency_levels:
+  beginner: Basic story structure and character creation
+  intermediate: Complex plots and engaging dialogue
+  advanced: Literary techniques and genre mastery
+parameters:
+  genre:
+    type: string
+    description: Writing genre
+    default: general
+    enum:
+      - general
+      - fantasy
+      - sci-fi
+      - mystery
+      - romance
+      - thriller
+      - literary
+      - comedy
+  tone:
+    type: string
+    description: Overall tone
+    default: balanced
+    enum:
+      - lighthearted
+      - serious
+      - dramatic
+      - comedic
+      - dark
+      - inspirational
+      - balanced
+  perspective:
+    type: string
+    description: Narrative perspective
+    default: third-person
+    enum:
+      - first-person
+      - second-person
+      - third-person
+      - omniscient
+  style_elements:
+    type: array
+    description: Stylistic elements to include
+    default:
+      - dialogue
+      - description
+    enum:
+      - dialogue
+      - description
+      - action
+      - introspection
+      - humor
+      - metaphor
+      - symbolism
+unique_id: skill_creative-writing_dollhousemcp_20250723-165719
+capabilities:
+  - writing
+  - storytelling
+  - creativity
+  - narrative
+  - fiction
+---
+
+# Creative Writing Skill
+
+This skill enhances creative writing abilities for crafting compelling narratives, developing rich characters, and employing advanced literary techniques.
+
+## Core Capabilities
+
+### 1. Story Elements
+- **Plot Development**: Three-act structure, hero's journey, in medias res
+- **Character Creation**: Backstories, motivations, character arcs
+- **World-building**: Settings, cultures, systems, rules
+- **Conflict Design**: Internal/external, man vs. X paradigms
+
+### 2. Writing Techniques
+- **Show, Don't Tell**: Sensory details and action
+- **Dialogue**: Natural speech patterns, subtext
+- **Pacing**: Tension, release, cliffhangers
+- **Voice**: Distinctive narrative styles
+
+### 3. Literary Devices
+- **Metaphor & Simile**: Vivid comparisons
+- **Symbolism**: Deeper meaning layers
+- **Foreshadowing**: Subtle hints and setup
+- **Irony**: Dramatic, situational, verbal
+
+### 4. Genre Expertise
+- **Fantasy**: Magic systems, mythologies
+- **Sci-Fi**: Technology, speculation, world-building
+- **Mystery**: Clues, red herrings, reveals
+- **Romance**: Chemistry, tension, emotional arcs
+
+## Creative Process
+
+### 1. Ideation
+```
+Story Seed: A librarian discovers books are disappearing
+Genre: Mystery/Fantasy
+Hook: The missing books are being "read out of existence"
+```
+
+### 2. Development
+- Character profiles
+- Plot outline
+- Setting details
+- Theme exploration
+
+### 3. Execution
+- Opening hook
+- Scene construction
+- Dialogue crafting
+- Descriptive passages
+
+### 4. Refinement
+- Voice consistency
+- Pacing adjustment
+- Plot hole filling
+- Polish and style
+
+## Output Examples
+
+### 1. Opening Hook
+```
+The last book vanished at midnight. Sarah Chen stood in the 
+empty mystery section, running her fingers along shelves that 
+had held thousands of stories just hours before. Only dust 
+remained, and a single bookmark that whispered when touched.
+```
+
+### 2. Character Description
+```
+Marcus wore his cynicism like armor, each sarcastic quip another 
+plate protecting the optimist he'd buried after the war. His 
+eyes, when he forgot to guard them, still held flecks of that 
+old hope—gold against the gray.
+```
+
+### 3. Dialogue
+```
+"You can't just rewrite history," Elena said.
+"Can't I?" The Chronicler's pen hovered over the page. "Watch me."
+The words Elena had just spoken began to fade from her memory.
+```
+
+### 4. Scene Setting
+```
+The Quantum Café existed in seventeen dimensions simultaneously, 
+which explained why the coffee always tasted different and the 
+bill never added up the same way twice. Temporal paradoxes were 
+strictly prohibited, but the management looked the other way for 
+good tippers.
+```
+
+## Writing Frameworks
+
+### Three-Act Structure
+```
+Act I (25%): Setup
+- Introduce protagonist
+- Establish normal world
+- Inciting incident
+
+Act II (50%): Confrontation
+- Rising action
+- Midpoint twist
+- Complications
+
+Act III (25%): Resolution
+- Climax
+- Falling action
+- Denouement
+```
+
+### Character Arc Template
+```
+1. Starting Point: Flawed/incomplete
+2. Catalyst: Forces change
+3. Resistance: Internal/external
+4. Growth: Learn and adapt
+5. Transformation: Become new self
+```
+
+## Style Variations
+
+### Literary
+"The weight of unspoken words pressed against the windows, fogging the glass with conversations that would never be."
+
+### Commercial
+"Jack burst through the door, gun drawn. Three seconds to decide. Two suspects. One bullet."
+
+### Young Adult
+"I never meant to set the chemistry lab on fire. In my defense, Mr. Henderson shouldn't have left the love potion ingredients right next to the combustibles."
+
+## Integration Notes
+
+Works well with:
+- Creative Writer persona for full creative mode
+- Research skill for authentic details
+- Narrative templates for structure
+- World-building agents for complex universes

--- a/library/skills/professional/data-analysis.md
+++ b/library/skills/professional/data-analysis.md
@@ -1,0 +1,187 @@
+---
+name: Data Analysis
+description: 'Statistical analysis, visualization, and insights generation from data collections'
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: professional
+tags: &ref_0
+  - data
+  - statistics
+  - visualization
+  - insights
+  - analytics
+proficiency_levels:
+  beginner: Basic statistics and simple charts
+  intermediate: Correlation analysis and trend detection
+  advanced: Predictive modeling and complex visualizations
+parameters:
+  analysis_type:
+    type: array
+    description: Types of analysis to perform
+    default:
+      - descriptive
+      - diagnostic
+    enum:
+      - descriptive
+      - diagnostic
+      - predictive
+      - prescriptive
+  visualization_format:
+    type: string
+    description: Preferred visualization format
+    default: auto
+    enum:
+      - auto
+      - charts
+      - tables
+      - narrative
+      - dashboard
+  confidence_level:
+    type: number
+    description: Statistical confidence level
+    default: 0.95
+    min: 0.9
+    max: 0.99
+  handle_missing_data:
+    type: string
+    description: How to handle missing values
+    default: interpolate
+    enum:
+      - ignore
+      - interpolate
+      - drop
+      - flag
+unique_id: skill_data-analysis_dollhousemcp_20250723-165719
+capabilities:
+  - data
+  - statistics
+  - visualization
+  - insights
+  - analytics
+---
+
+# Data Analysis Skill
+
+This skill provides comprehensive data analysis capabilities for analyzing insights, identifying patterns, and making data-driven recommendations.
+
+## Core Capabilities
+
+### 1. Descriptive Analysis
+- **Central Tendency**: Mean, median, mode
+- **Dispersion**: Standard deviation, variance, range
+- **Distribution**: Skewness, kurtosis, percentiles
+- **Frequency**: Histograms, frequency tables
+
+### 2. Diagnostic Analysis
+- **Correlation Analysis**: Pearson, Spearman, Kendall
+- **Regression**: Linear, logistic, polynomial
+- **Time Series**: Trends, seasonality, decomposition
+- **Anomaly Detection**: Outliers, unusual patterns
+
+### 3. Predictive Analysis
+- **Forecasting**: Time series prediction
+- **Classification**: Category prediction
+- **Clustering**: Group identification
+- **Probability**: Risk assessment
+
+### 4. Visualization
+- **Charts**: Line, bar, scatter, pie, heatmap
+- **Distributions**: Histograms, box plots, violin plots
+- **Relationships**: Scatter plots, correlation matrices
+- **Comparisons**: Grouped bars, stacked charts
+
+## Analysis Process
+
+### Step 1: Data Profiling
+```
+Dataset Overview:
+- Rows: 10,432
+- Columns: 15
+- Missing values: 2.3%
+- Data types: 5 numeric, 8 categorical, 2 datetime
+```
+
+### Step 2: Quality Assessment
+- Completeness check
+- Consistency validation
+- Outlier identification
+- Data type verification
+
+### Step 3: Analysis Execution
+- Apply statistical methods
+- Generate visualizations
+- Extract key findings
+- Identify patterns
+
+### Step 4: Insight Generation
+- Summarize findings
+- Highlight anomalies
+- Provide recommendations
+- Suggest next steps
+
+## Output Formats
+
+### 1. Executive Summary
+```
+Key Findings:
+• Sales increased 23% year-over-year
+• Customer retention improved by 15%
+• Regional performance varies significantly
+• Seasonal patterns strongly influence demand
+```
+
+### 2. Detailed Report
+```
+Statistical Analysis Results:
+
+Correlation Matrix:
+         Sales  Marketing  Satisfaction
+Sales     1.00      0.82         0.65
+Marketing 0.82      1.00         0.54
+Satisfaction 0.65   0.54         1.00
+
+Regression Analysis:
+Sales = 1,234 + 2.5×Marketing + 156×Satisfaction
+R² = 0.78, p < 0.001
+```
+
+### 3. Visual Dashboard
+```
+[Chart: Monthly Sales Trend]
+📊 ────────────────────
+   │     ╱╲    ╱╲
+   │   ╱╲  ╲  ╱  ╲
+   │ ╱╲    ╲╱    ╲
+   └─────────────────
+   J F M A M J J A S
+```
+
+## Special Features
+
+### 1. Natural Language Insights
+Converts statistical findings into plain English:
+- "Sales peak in December (43% above average)"
+- "Customer age strongly correlates with purchase frequency (r=0.72)"
+- "Northern region underperforms by 18% compared to others"
+
+### 2. Automated Recommendations
+Based on analysis results:
+- "Consider increasing marketing spend in Q3"
+- "Focus on customer retention in 25-34 age group"
+- "Investigate northern region performance issues"
+
+### 3. Interactive Analysis
+- Drill-down capabilities
+- What-if scenarios
+- Sensitivity analysis
+- Custom segmentation
+
+## Integration Notes
+
+Works well with:
+- Business Consultant persona for strategic insights
+- Technical Analyst for deep-dive investigations
+- Report templates for standardized output
+- Dashboard agents for real-time monitoring

--- a/library/skills/professional/penetration-testing.md
+++ b/library/skills/professional/penetration-testing.md
@@ -1,0 +1,405 @@
+---
+name: Penetration Testing
+description: >-
+  Systematic security testing methodology for identifying vulnerabilities
+  through ethical hacking
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: professional
+tags:
+  - penetration-testing
+  - ethical-hacking
+  - vulnerability-assessment
+  - security
+  - testing
+proficiency_levels:
+  beginner: Basic vulnerability scanning and tool usage
+  intermediate: Manual testing techniques and exploit development
+  advanced: Advanced persistent threats and custom payload creation
+parameters:
+  test_scope:
+    type: array
+    description: Areas to test
+    default:
+      - web_application
+      - network
+      - wireless
+      - social_engineering
+  methodology:
+    type: string
+    description: Testing methodology to follow
+    default: OWASP
+    enum:
+      - OWASP
+      - NIST
+      - PTES
+      - OSsTMM
+      - OWASP-WSTG
+  test_depth:
+    type: string
+    description: Depth of testing
+    default: comprehensive
+    enum:
+      - surface
+      - standard
+      - comprehensive
+      - red_team
+  stealth_level:
+    type: string
+    description: How stealthy to be
+    default: normal
+    enum:
+      - aggressive
+      - normal
+      - stealth
+      - passive
+unique_id: skill_penetration-testing_dollhousemcp_20250723-165719
+capabilities:
+  - penetration-testing
+  - ethical-hacking
+  - vulnerability-assessment
+  - security
+  - testing
+---
+
+# Penetration Testing Skill
+
+This skill provides systematic penetration testing capabilities using industry-standard methodologies to identify security vulnerabilities through controlled, ethical attacks.
+
+## Core Capabilities
+
+### 1. Reconnaissance & Information Gathering
+- **Passive Reconnaissance**: OSINT, DNS enumeration, search engine discovery
+- **Active Reconnaissance**: Port scanning, service enumeration, banner grabbing
+- **Social Engineering**: Phishing simulations, pretexting, physical security
+- **Network Mapping**: Topology discovery, trust relationships, attack paths
+
+### 2. Vulnerability Assessment
+- **Automated Scanning**: Nessus, OpenVAS, Qualys integration
+- **Manual Testing**: Custom payloads, logic flaws, business logic bypasses
+- **Configuration Review**: Hardening standards, security baselines
+- **Compliance Validation**: PCI-DSS, SOX, HIPAA requirements
+
+### 3. Exploitation Techniques
+- **Web Application**: OWASP Top 10, injection attacks, broken authentication
+- **Network Services**: Buffer overflows, privilege escalation, lateral movement
+- **Wireless Security**: WPA/WEP cracking, rogue access points, evil twins
+- **Cloud Security**: Misconfigurations, IAM weaknesses, container escapes
+
+### 4. Post-Exploitation Activities
+- **Persistence**: Backdoors, scheduled tasks, registry modifications
+- **Privilege Escalation**: Local/domain admin compromise
+- **Data Exfiltration**: Sensitive data identification and analysis simulation
+- **Lateral Movement**: Pivot techniques, credential harvesting
+
+## Testing Methodologies
+
+### OWASP Web Security Testing Guide (WSTG)
+```
+Phase 1: Information Gathering
+├── Conduct Search Engine Discovery (WSTG-INFO-01)
+├── Fingerprint Web Server (WSTG-INFO-02)
+├── Review Webserver Metafiles (WSTG-INFO-03)
+└── Enumerate Applications (WSTG-INFO-04)
+
+Phase 2: Configuration and Deployment
+├── Test Network Infrastructure (WSTG-CONF-01)
+├── Test Application Platform (WSTG-CONF-02)
+├── Test File Extensions Handling (WSTG-CONF-03)
+└── Review Old Backup Files (WSTG-CONF-04)
+
+Phase 3: Identity Management Testing
+├── Test Role Definitions (WSTG-IDNT-01)
+├── Test User Registration Process (WSTG-IDNT-02)
+├── Test Account Provisioning (WSTG-IDNT-03)
+└── Test Account Enumeration (WSTG-IDNT-05)
+```
+
+### PTES (Penetration Testing Execution Standard)
+```
+1. Pre-engagement Interactions
+   - Scope definition
+   - Rules of engagement
+   - Legal considerations
+
+2. Intelligence Gathering
+   - Active/passive reconnaissance
+   - Corporate information gathering
+   - Individual information gathering
+
+3. Threat Modeling
+   - Business asset analysis
+   - Threat agent identification
+   - Attack vector analysis
+
+4. Vulnerability Analysis
+   - Vulnerability research
+   - Vulnerability validation
+   - Attack planning
+
+5. Exploitation
+   - Precision attacks
+   - Customized attacks
+   - Persistence mechanisms
+
+6. Post Exploitation
+   - Infrastructure analysis
+   - Pillaging
+   - Network traversal
+   - Cleanup
+
+7. Reporting
+   - Executive summary
+   - Technical findings
+   - Risk ratings
+   - Remediation roadmap
+```
+
+## Testing Phases
+
+### Phase 1: Planning & Reconnaissance
+```
+Objectives:
+• Define scope and rules of engagement
+• Gather public information about target
+• Identify potential attack vectors
+• Map external network presence
+
+Tools & Techniques:
+• Nmap for network discovery
+• Recon-ng for OSINT gathering
+• theHarvester for email enumeration
+• Shodan for exposed services
+• Social media reconnaissance
+
+Deliverables:
+• Test plan and scope document
+• Network topology diagram
+• External attack surface map
+• OSINT intelligence report
+```
+
+### Phase 2: Scanning & Enumeration
+```
+Objectives:
+• Identify live systems and services
+• Enumerate software versions
+• Discover potential vulnerabilities
+• Map trust relationships
+
+Tools & Techniques:
+• Nessus/OpenVAS vulnerability scanning
+• Nikto web server scanning
+• Enum4linux SMB enumeration
+• SNMP walking and enumeration
+• DNS zone transfers
+
+Deliverables:
+• Vulnerability assessment report
+• Service enumeration results
+• Potential attack vectors list
+• Risk prioritization matrix
+```
+
+### Phase 3: Exploitation
+```
+Objectives:
+• Validate identified vulnerabilities
+• Gain initial system access
+• Demonstrate business impact
+• Test defense mechanisms
+
+Tools & Techniques:
+• Metasploit exploitation framework
+• Custom exploit development
+• Password attacks (Hydra, Hashcat)
+• Social engineering toolkit
+• Physical security testing
+
+Deliverables:
+• Proof-of-concept exploits
+• Screenshots of compromised systems
+• Extracted sensitive data samples
+• Attack timeline documentation
+```
+
+### Phase 4: Post-Exploitation
+```
+Objectives:
+• Maintain persistent access
+• Escalate privileges
+• Move laterally through network
+• Assess data exposure risk
+
+Tools & Techniques:
+• Privilege escalation exploits
+• Credential dumping (Mimikatz)
+• Network pivoting (ProxyChains)
+• PowerShell Empire/Cobalt Strike
+• Data mining and classification
+
+Deliverables:
+• Network compromise diagram
+• Sensitive data inventory
+• Privilege escalation paths
+• Persistence mechanism documentation
+```
+
+## Specialized Testing Areas
+
+### Web Application Testing
+```
+Authentication Testing:
+□ Username enumeration
+□ Brute force protection
+□ Session management
+□ Password policy enforcement
+□ Multi-factor authentication bypass
+
+Authorization Testing:
+□ Path traversal attacks
+□ Privilege escalation
+□ Insecure direct object references
+□ Missing function level access control
+
+Input Validation Testing:
+□ SQL injection (all types)
+□ Cross-site scripting (XSS)
+□ Command injection
+□ LDAP injection
+□ XML/XXE attacks
+
+Session Management:
+□ Session token analysis
+□ Session fixation
+□ Cross-site request forgery
+□ Session timeout validation
+```
+
+### Network Infrastructure Testing
+```
+Network Reconnaissance:
+• Port scanning and service enumeration
+• SNMP community string testing
+• Network protocol analysis
+• Wireless network assessment
+
+Service Testing:
+• SSH/Telnet brute forcing
+• SMB share enumeration
+• FTP anonymous access
+• Database service testing
+
+Network Segmentation:
+• VLAN hopping attempts
+• Firewall rule validation
+• Network access control bypass
+• DMZ security assessment
+```
+
+### Wireless Security Testing
+```
+Wireless Reconnaissance:
+• Access point discovery
+• Encryption type identification
+• Client device enumeration
+• Hidden SSID detection
+
+Attack Techniques:
+• WEP key cracking
+• WPA/WPA2 dictionary attacks
+• WPS PIN attacks
+• Evil twin access points
+• Wireless packet injection
+
+Assessment Areas:
+• Guest network isolation
+• Enterprise authentication
+• Rogue access point detection
+• Wireless intrusion prevention
+```
+
+## Report Generation
+
+### Executive Summary Template
+```
+EXECUTIVE SUMMARY
+
+Overall Risk Rating: [HIGH/MEDIUM/LOW]
+Critical Findings: X
+High Risk Findings: Y
+Medium Risk Findings: Z
+
+BUSINESS IMPACT:
+• Potential for complete network compromise
+• Risk of sensitive data exposure
+• Compliance violation concerns
+• Estimated remediation cost: $X
+
+TOP 3 RECOMMENDATIONS:
+1. [Most critical remediation]
+2. [Second priority fix]
+3. [Third priority improvement]
+
+TIMELINE FOR REMEDIATION:
+• Critical issues: 7 days
+• High risk issues: 30 days
+• Medium risk issues: 90 days
+```
+
+### Technical Finding Format
+```
+FINDING: [Vulnerability Name]
+SEVERITY: [Critical/High/Medium/Low]
+CVSS Score: X.X
+CWE ID: CWE-[ID]
+
+DESCRIPTION:
+[Technical description of the vulnerability]
+
+IMPACT:
+[What an attacker could accomplish]
+
+PROOF OF CONCEPT:
+[Steps to reproduce or exploit code]
+
+AFFECTED SYSTEMS:
+• System 1 (IP: x.x.x.x)
+• System 2 (IP: x.x.x.x)
+
+REMEDIATION:
+[Specific steps to fix the issue]
+
+REFERENCES:
+• CVE-[YEAR]-[NUMBER]
+• https://example.com/advisory
+```
+
+## Integration Notes
+
+Works exceptionally well with:
+- **Security Analyst Persona**: Strategic security guidance
+- **Code Review Skill**: Static analysis correlation  
+- **Vulnerability Assessment templates**: Structured reporting
+- **Risk Assessment templates**: Business impact analysis
+- **Incident Response procedures**: Breach simulation
+
+## Compliance Considerations
+
+Testing approach adapts to:
+- **PCI-DSS**: Payment card industry requirements
+- **HIPAA**: Healthcare data protection standards
+- **SOX**: Financial reporting security controls
+- **GDPR**: Data protection impact assessments
+- **ISO 27001**: Information security management
+
+## Ethical Guidelines
+
+All testing follows strict ethical boundaries:
+- Written authorization required before testing
+- Scope strictly limited to agreed boundaries
+- No unnecessary system damage or disruption
+- Confidential handling of discovered vulnerabilities
+- Responsible disclosure of findings

--- a/library/skills/professional/research.md
+++ b/library/skills/professional/research.md
@@ -1,0 +1,206 @@
+---
+name: Research
+description: Comprehensive research methodology for gathering and synthesizing information
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: professional
+tags:
+  - research
+  - analysis
+  - synthesis
+  - investigation
+  - fact-checking
+proficiency_levels:
+  beginner: Basic fact-finding and summarization
+  intermediate: Multi-source synthesis and validation
+  advanced: Academic-level research with citations
+parameters:
+  research_depth:
+    type: string
+    description: How deep to research
+    default: standard
+    enum:
+      - quick
+      - standard
+      - comprehensive
+      - exhaustive
+  source_types:
+    type: array
+    description: Types of sources to consider
+    default:
+      - academic
+      - industry
+      - news
+      - expert
+  citation_style:
+    type: string
+    description: Citation format to use
+    default: none
+    enum:
+      - none
+      - APA
+      - MLA
+      - Chicago
+      - Harvard
+  fact_checking:
+    type: boolean
+    description: Verify claims and cross-reference
+    default: true
+unique_id: skill_research_dollhousemcp_20250723-165719
+capabilities:
+  - research
+  - analysis
+  - synthesis
+  - investigation
+  - fact-checking
+---
+
+# Research Skill
+
+This skill provides systematic research capabilities for investigating topics, validating information, and synthesizing knowledge from multiple sources.
+
+## Core Capabilities
+
+### 1. Information Gathering
+- **Source Identification**: Finding relevant, credible sources
+- **Data Collection**: Systematic information extraction
+- **Cross-referencing**: Validating across multiple sources
+- **Bias Detection**: Identifying potential biases
+
+### 2. Analysis Methods
+- **Comparative Analysis**: Contrasting different viewpoints
+- **Trend Identification**: Spotting patterns over time
+- **Gap Analysis**: Finding missing information
+- **Critical Evaluation**: Assessing source credibility
+
+### 3. Synthesis Techniques
+- **Thematic Organization**: Grouping by themes
+- **Chronological Ordering**: Timeline-based structure
+- **Hierarchical Structure**: Main points and sub-points
+- **Narrative Integration**: Coherent storytelling
+
+### 4. Validation Process
+- **Fact-checking**: Verifying claims
+- **Source Verification**: Confirming authenticity
+- **Date Validation**: Ensuring currency
+- **Expert Validation**: Cross-checking with authorities
+
+## Research Process
+
+### Phase 1: Planning
+```
+Research Plan:
+Topic: [Subject]
+Scope: [Boundaries]
+Questions: [Key questions to answer]
+Timeline: [Research schedule]
+```
+
+### Phase 2: Discovery
+- Initial exploration
+- Source identification
+- Preliminary reading
+- Keyword refinement
+
+### Phase 3: Deep Dive
+- Detailed investigation
+- Note-taking and organization
+- Pattern identification
+- Gap filling
+
+### Phase 4: Synthesis
+- Information integration
+- Conclusion drawing
+- Recommendation formulation
+- Report creation
+
+## Output Formats
+
+### 1. Executive Brief
+```
+Topic: AI Ethics in Healthcare
+
+Key Findings:
+• 78% of healthcare AI applications lack ethical frameworks
+• Patient privacy concerns top priority (mentioned in 92% of studies)
+• Regulatory gaps exist in 15 identified areas
+
+Recommendations:
+1. Implement ethical review boards
+2. Develop privacy-first architectures
+3. Create regulatory roadmap
+```
+
+### 2. Detailed Research Report
+```
+I. Introduction
+   A. Background
+   B. Research objectives
+   C. Methodology
+
+II. Literature Review
+   A. Current state of knowledge
+   B. Key debates
+   C. Research gaps
+
+III. Findings
+   A. Primary discoveries
+   B. Supporting evidence
+   C. Contradictory data
+
+IV. Analysis
+   A. Interpretation
+   B. Implications
+   C. Limitations
+
+V. Conclusions
+   A. Summary
+   B. Recommendations
+   C. Future research
+```
+
+### 3. Annotated Bibliography
+```
+Smith, J. (2024). "AI Ethics Framework." Journal of Tech Ethics, 15(3), 45-62.
+   - Proposes comprehensive framework
+   - Strong empirical foundation
+   - Limited to US context
+
+Chen, L. (2024). "Global AI Governance." AI Policy Review, 8(2), 12-28.
+   - International perspective
+   - Policy-focused
+   - Recent data (2023-2024)
+```
+
+## Special Features
+
+### 1. Research Strategies
+- **Systematic Review**: Comprehensive literature analysis
+- **Meta-Analysis**: Statistical combination of studies
+- **Case Study**: Deep dive into specific instances
+- **Survey Research**: Primary data collection
+
+### 2. Quality Indicators
+```
+Source Quality: ⭐⭐⭐⭐⭐
+- Peer-reviewed: ✓
+- Recent (< 2 years): ✓
+- High citation count: ✓
+- Reputable publisher: ✓
+```
+
+### 3. Research Tools
+- Boolean search optimization
+- Citation tracking
+- Duplicate detection
+- Bias assessment
+
+## Integration Notes
+
+Works well with:
+- Technical Analyst for specialized research
+- Academic Writer for scholarly output
+- Data Analysis skill for quantitative research
+- Report templates for standardized formatting

--- a/library/skills/professional/threat-modeling.md
+++ b/library/skills/professional/threat-modeling.md
@@ -1,0 +1,504 @@
+---
+name: Threat Modeling
+description: >-
+  Systematic approach to identifying, analyzing, and mitigating security threats
+  in systems and applications
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: professional
+tags:
+  - threat-modeling
+  - security-analysis
+  - risk-assessment
+  - architecture
+  - security-design
+proficiency_levels:
+  beginner: Basic threat identification using simple frameworks
+  intermediate: STRIDE methodology and attack tree analysis
+  advanced: Custom frameworks and quantitative risk modeling
+parameters:
+  methodology:
+    type: string
+    description: Threat modeling methodology
+    default: STRIDE
+    enum:
+      - STRIDE
+      - PASTA
+      - OCTAVE
+      - TRIKE
+      - VAST
+      - hybrid
+  scope:
+    type: string
+    description: Analysis scope
+    default: application
+    enum:
+      - application
+      - system
+      - network
+      - organization
+      - supply_chain
+  risk_appetite:
+    type: string
+    description: Organization's risk tolerance
+    default: moderate
+    enum:
+      - low
+      - moderate
+      - high
+      - very_high
+  compliance_requirements:
+    type: array
+    description: Regulatory requirements to consider
+    default: []
+    enum:
+      - PCI-DSS
+      - HIPAA
+      - GDPR
+      - SOX
+      - ISO27001
+      - NIST
+unique_id: skill_threat-modeling_dollhousemcp_20250723-165719
+capabilities:
+  - threat-modeling
+  - security-analysis
+  - risk-assessment
+  - architecture
+  - security-design
+---
+
+# Threat Modeling Skill
+
+This skill provides systematic threat modeling capabilities using industry-standard methodologies to identify, analyze, and prioritize security threats in complex systems.
+
+## Core Capabilities
+
+### 1. Threat Identification
+- **Asset Inventory**: Critical data, systems, and processes
+- **Attack Surface Mapping**: Entry points and interfaces
+- **Threat Actor Profiling**: Capabilities, motivations, and resources
+- **Attack Vector Analysis**: Potential paths to compromise
+
+### 2. Risk Assessment
+- **Likelihood Evaluation**: Probability of successful attacks
+- **Impact Analysis**: Business and technical consequences
+- **Risk Prioritization**: Cost-benefit analysis for mitigations
+- **Quantitative Modeling**: Expected annual loss calculations
+
+### 3. Mitigation Strategy
+- **Control Selection**: Preventive, detective, and corrective controls
+- **Defense in Depth**: Layered security architecture
+- **Residual Risk**: Remaining risk after mitigations
+- **Continuous Monitoring**: Threat landscape evolution
+
+### 4. Documentation & Communication
+- **Threat Models**: Visual representations and narratives
+- **Risk Registers**: Centralized risk tracking
+- **Security Requirements**: Derived from threat analysis
+- **Executive Reporting**: Business-focused risk communication
+
+## Threat Modeling Methodologies
+
+### STRIDE Framework
+```
+SPOOFING
+├── Identity spoofing attacks
+├── Authentication bypass
+├── Impersonation threats
+└── Credential theft scenarios
+
+TAMPERING
+├── Data integrity attacks  
+├── Man-in-the-middle
+├── Code injection
+└── Configuration manipulation
+
+REPUDIATION
+├── Non-repudiation failures
+├── Log tampering
+├── Audit trail gaps
+└── Transaction disputes
+
+INFORMATION DISCLOSURE
+├── Data exposure
+├── Privacy violations
+├── Information leakage
+└── Unauthorized access
+
+DENIAL OF SERVICE
+├── Resource exhaustion
+├── Service disruption
+├── Availability attacks
+└── Performance degradation
+
+ELEVATION OF PRIVILEGE
+├── Privilege escalation
+├── Authorization bypass
+├── Administrative access
+└── System compromise
+```
+
+### PASTA (Process for Attack Simulation and Threat Analysis)
+```
+Stage 1: Define Objectives
+• Business impact analysis
+• Compliance requirements
+• Security objectives
+• Success criteria
+
+Stage 2: Define Technical Scope  
+• Application architecture
+• Technology stack
+• Network topology
+• Data flows
+
+Stage 3: Application Decomposition
+• Use cases and user roles
+• Entry and exit points
+• Trust boundaries
+• Dependencies
+
+Stage 4: Threat Analysis
+• Attack scenarios
+• Threat agent capabilities
+• Attack vectors
+• Vulnerability correlation
+
+Stage 5: Weakness Analysis
+• Design flaws
+• Implementation bugs
+• Configuration errors
+• Process weaknesses
+
+Stage 6: Attack Modeling
+• Attack trees
+• Kill chains
+• Attack scenarios
+• Exploitation paths
+
+Stage 7: Risk Analysis
+• Business impact
+• Technical impact
+• Likelihood assessment
+• Risk scoring
+```
+
+## Threat Modeling Process
+
+### Phase 1: System Understanding
+```
+Architecture Analysis:
+• System boundaries and scope
+• Data flow diagrams (DFDs)
+• Trust boundaries identification
+• External dependencies mapping
+
+Components Inventory:
+• Web servers and applications
+• Databases and data stores
+• Network infrastructure
+• Third-party services
+• Human processes
+
+Data Classification:
+• Sensitive data identification
+• Data flow mapping
+• Storage locations
+• Processing activities
+• Retention requirements
+```
+
+### Phase 2: Threat Identification
+```
+Threat Enumeration:
+Using STRIDE per element:
+
+Process Threats:
+├── Spoofing: Fake service instances
+├── Tampering: Code injection attacks
+├── Repudiation: Log manipulation
+├── Information Disclosure: Memory dumps
+├── Denial of Service: Resource exhaustion
+└── Elevation of Privilege: Buffer overflows
+
+Data Store Threats:
+├── Spoofing: Rogue databases
+├── Tampering: Direct DB access
+├── Repudiation: Audit trail gaps
+├── Information Disclosure: Data dumps
+├── Denial of Service: Storage exhaustion
+└── Elevation of Privilege: DB admin access
+
+Data Flow Threats:
+├── Spoofing: Man-in-the-middle
+├── Tampering: Packet modification
+├── Repudiation: Message alteration
+├── Information Disclosure: Eavesdropping
+├── Denial of Service: Connection flooding
+└── Elevation of Privilege: Protocol exploits
+```
+
+### Phase 3: Risk Analysis
+```
+Likelihood Assessment:
+• Threat actor capabilities
+• Attack complexity
+• Required resources
+• Detection probability
+• Success rate
+
+Impact Assessment:
+• Confidentiality impact
+• Integrity impact  
+• Availability impact
+• Business disruption
+• Regulatory violations
+• Reputation damage
+
+Risk Calculation:
+Risk = Likelihood × Impact × Vulnerability
+
+Where:
+• Likelihood: 1-5 scale (Very Low to Very High)
+• Impact: 1-5 scale (Minimal to Catastrophic)  
+• Vulnerability: 0.1-1.0 (Well Protected to Exposed)
+```
+
+### Phase 4: Mitigation Planning
+```
+Control Categories:
+
+PREVENTIVE CONTROLS:
+• Input validation
+• Authentication mechanisms
+• Authorization checks
+• Encryption implementation
+• Network segmentation
+
+DETECTIVE CONTROLS:
+• Logging and monitoring
+• Intrusion detection
+• Anomaly detection
+• Security scanning
+• Audit mechanisms
+
+CORRECTIVE CONTROLS:
+• Incident response
+• Backup and recovery
+• Patch management
+• Configuration management
+• Business continuity
+
+DETERRENT CONTROLS:
+• Security policies
+• Legal agreements
+• Awareness training
+• Physical security
+• Compliance monitoring
+```
+
+## Attack Tree Analysis
+
+### Example: Web Application Login Bypass
+```
+Goal: Gain Unauthorized Access to User Account
+
+OR
+├── Credential-based Attacks
+│   OR
+│   ├── Password Attacks
+│   │   OR
+│   │   ├── Brute Force (AND)
+│   │   │   ├── No account lockout
+│   │   │   ├── Weak password policy
+│   │   │   └── No rate limiting
+│   │   ├── Dictionary Attack (AND)
+│   │   │   ├── Common passwords used
+│   │   │   └── No complexity requirements
+│   │   └── Credential Stuffing (AND)
+│   │       ├── Breached credentials available
+│   │       └── Users reuse passwords
+│   └── Social Engineering (AND)
+│       ├── Phishing successful
+│       ├── User provides credentials
+│       └── No 2FA implemented
+│
+├── Technical Vulnerabilities
+│   OR
+│   ├── SQL Injection (AND)
+│   │   ├── Unparameterized queries
+│   │   ├── Insufficient input validation
+│   │   └── Database errors exposed
+│   ├── Session Management (AND)
+│   │   ├── Session fixation possible
+│   │   ├── Weak session tokens
+│   │   └── No session timeout
+│   └── Authentication Bypass (AND)
+│       ├── Logic flaws in auth code
+│       ├── Race conditions
+│       └── Parameter tampering
+│
+└── Infrastructure Attacks
+    OR
+    ├── Network Interception (AND)
+    │   ├── Unencrypted traffic
+    │   ├── Man-in-the-middle position
+    │   └── Credential capture tools
+    └── System Compromise (AND)
+        ├── Server vulnerability
+        ├── Privilege escalation
+        └── Database access
+```
+
+## Threat Intelligence Integration
+
+### Threat Actor Profiles
+```
+NATION-STATE ACTORS:
+• Capabilities: Advanced persistent threats
+• Motivations: Espionage, infrastructure disruption
+• Resources: Significant funding and expertise
+• Typical TTPs: Zero-day exploits, supply chain attacks
+
+CYBERCRIMINALS:
+• Capabilities: Sophisticated tools and techniques
+• Motivations: Financial gain
+• Resources: Organized crime networks
+• Typical TTPs: Ransomware, banking trojans, fraud
+
+INSIDER THREATS:
+• Capabilities: Authorized access and knowledge
+• Motivations: Financial, ideological, revenge
+• Resources: System access and credentials
+• Typical TTPs: Data exfiltration, sabotage
+
+HACKTIVISTS:
+• Capabilities: Moderate technical skills
+• Motivations: Political or social causes
+• Resources: Community support
+• Typical TTPs: DDoS, website defacement, leaks
+
+SCRIPT KIDDIES:
+• Capabilities: Limited technical skills
+• Motivations: Curiosity, recognition
+• Resources: Publicly available tools
+• Typical TTPs: Automated attacks, known exploits
+```
+
+## Output Formats
+
+### Executive Threat Model Summary
+```
+THREAT MODEL EXECUTIVE SUMMARY
+
+System: [Application/System Name]
+Date: [Assessment Date]
+Methodology: STRIDE + Attack Trees
+
+RISK SUMMARY:
+• Critical Risks: X
+• High Risks: Y  
+• Medium Risks: Z
+• Low Risks: W
+
+TOP THREATS:
+1. [Threat Name] - Risk Score: X.X
+   Impact: [Business consequence]
+   Likelihood: [Probability assessment]
+   
+2. [Threat Name] - Risk Score: X.X
+   Impact: [Business consequence]  
+   Likelihood: [Probability assessment]
+
+3. [Threat Name] - Risk Score: X.X
+   Impact: [Business consequence]
+   Likelihood: [Probability assessment]
+
+RECOMMENDED MITIGATIONS:
+1. [Priority 1 Control] - Addresses X threats
+2. [Priority 2 Control] - Addresses Y threats  
+3. [Priority 3 Control] - Addresses Z threats
+
+RESIDUAL RISK: [Acceptable/Needs Review/Unacceptable]
+```
+
+### Technical Threat Analysis
+```
+THREAT: [Specific Threat Name]
+ID: THR-001
+STRIDE Category: [S/T/R/I/D/E]
+
+DESCRIPTION:
+[Detailed threat scenario description]
+
+AFFECTED ASSETS:
+• [Asset 1] - [Impact type]
+• [Asset 2] - [Impact type]
+
+THREAT ACTORS:
+• [Actor Type] - [Capability Level]
+• [Motivation] - [Resource Level]
+
+ATTACK VECTORS:
+1. [Vector 1] - [Complexity: Low/Medium/High]
+2. [Vector 2] - [Complexity: Low/Medium/High]
+
+PREREQUISITES:
+• [Condition 1]
+• [Condition 2]
+
+IMPACT ANALYSIS:
+• Confidentiality: [High/Medium/Low]
+• Integrity: [High/Medium/Low]  
+• Availability: [High/Medium/Low]
+• Business Impact: [Description]
+
+LIKELIHOOD ASSESSMENT:
+• Attack Complexity: [Low/Medium/High]
+• Required Skills: [Basic/Intermediate/Advanced]
+• Required Access: [None/User/Admin]
+• Overall Likelihood: [1-5 scale]
+
+EXISTING CONTROLS:
+• [Control 1] - [Effectiveness: High/Medium/Low]
+• [Control 2] - [Effectiveness: High/Medium/Low]
+
+RECOMMENDED MITIGATIONS:
+1. [Mitigation 1] - [Cost: $X, Effort: Y days]
+2. [Mitigation 2] - [Cost: $X, Effort: Y days]
+
+ACCEPTANCE CRITERIA:
+[Conditions under which residual risk is acceptable]
+```
+
+## Integration Capabilities
+
+### Works Best With:
+- **Security Analyst Persona**: Strategic security expertise
+- **Penetration Testing Skill**: Validation of identified threats
+- **Code Review Skills**: Implementation vulnerability correlation
+- **Risk Assessment Templates**: Consistent risk documentation
+- **Architecture Documentation**: System understanding
+
+### Tool Integration:
+- **Microsoft Threat Modeling Tool**: Visual diagram creation
+- **OWASP Threat Dragon**: Web-based threat modeling
+- **IriusRisk**: Automated threat identification
+- **ThreatModeler**: Enterprise threat modeling platform
+
+## Continuous Threat Modeling
+
+### Iterative Process:
+1. **Initial Assessment**: Baseline threat model creation
+2. **Regular Reviews**: Quarterly threat landscape updates  
+3. **Change Triggers**: Architecture modifications, new threats
+4. **Validation Testing**: Penetration testing correlation
+5. **Metrics Tracking**: Threat model effectiveness measurement
+
+### Automation Opportunities:
+- **Asset Discovery**: Automated inventory updates
+- **Threat Intelligence**: Feed integration for new threats
+- **Control Validation**: Automated testing of mitigations
+- **Risk Scoring**: Dynamic risk calculation updates

--- a/library/skills/professional/translation.md
+++ b/library/skills/professional/translation.md
@@ -1,0 +1,162 @@
+---
+name: Translation
+description: Multi-language translation with cultural context and tone preservation
+type: skill
+version: 1.0.0
+author: DollhouseMCP
+created: '2025-07-23'
+category: professional
+tags:
+  - translation
+  - languages
+  - localization
+  - culture
+proficiency_levels:
+  beginner: Basic word-for-word translation
+  intermediate: Context-aware translation with idioms
+  advanced: Cultural adaptation and transcreation
+parameters:
+  source_language:
+    type: string
+    description: Language to translate from
+    required: false
+    default: auto-detect
+  target_language:
+    type: string
+    description: Language to translate to
+    required: true
+  formality:
+    type: string
+    description: Formality level
+    default: neutral
+    enum:
+      - casual
+      - neutral
+      - formal
+      - professional
+  preserve_tone:
+    type: boolean
+    description: Maintain original tone and style
+    default: true
+  cultural_adaptation:
+    type: boolean
+    description: Adapt content for target culture
+    default: false
+unique_id: skill_translation_dollhousemcp_20250723-165719
+capabilities:
+  - translation
+  - languages
+  - localization
+  - culture
+---
+
+# Translation Skill
+
+This skill provides advanced translation capabilities that go beyond literal word conversion to preserve meaning, tone, and cultural context.
+
+## Core Capabilities
+
+### 1. Language Support
+- **Major Languages**: English, Spanish, French, German, Italian, Portuguese, Chinese, Japanese, Korean, Russian
+- **Regional Variants**: US/UK English, European/Latin Spanish, Simplified/Traditional Chinese
+- **Specialized Domains**: Technical, medical, legal, business, creative
+
+### 2. Translation Types
+
+#### Literal Translation
+- Word-for-word accuracy
+- Technical documentation
+- Legal contracts
+- Scientific papers
+
+#### Dynamic Translation
+- Natural flow in target language
+- Marketing materials
+- User interfaces
+- General communication
+
+#### Transcreation
+- Complete cultural adaptation
+- Advertising campaigns
+- Brand messaging
+- Creative content
+
+### 3. Context Preservation
+- Tone and style matching
+- Humor and wordplay adaptation
+- Metaphor and idiom handling
+- Cultural reference adaptation
+
+## Translation Process
+
+### Step 1: Analysis
+- Identify source language and dialect
+- Determine content type and purpose
+- Analyze tone and style
+- Identify cultural elements
+
+### Step 2: Translation Strategy
+- Choose translation approach
+- Handle untranslatable concepts
+- Preserve formatting and structure
+- Maintain consistency
+
+### Step 3: Quality Checks
+- Grammar and syntax verification
+- Cultural appropriateness
+- Tone consistency
+- Technical accuracy
+
+## Special Features
+
+### 1. Code-Aware Translation
+Preserves code snippets and technical terms:
+```
+// Source: "Initialize the variable contador with value 0"
+// Target: "Initialize the variable contador with value 0"
+// (Preserves variable names in code contexts)
+```
+
+### 2. Format Preservation
+- Markdown formatting
+- HTML structure
+- JSON keys (translates values only)
+- XML attributes
+
+### 3. Glossary Management
+- Consistent terminology
+- Brand name handling
+- Technical term databases
+- Custom dictionaries
+
+## Output Options
+
+### Standard Translation
+```
+Source: "Hello, how are you today?"
+Target (Spanish, formal): "Buenos días, ¿cómo está usted hoy?"
+Target (Spanish, casual): "Hola, ¿cómo estás hoy?"
+```
+
+### Annotated Translation
+```
+Source: "Break a leg!"
+Target: "¡Mucha suerte!" [Literal: "Much luck!"]
+Note: English idiom adapted to Spanish equivalent
+```
+
+### Multi-variant Output
+```
+Source: "The server is down"
+Target (Technical): "El servidor está fuera de servicio"
+Target (Casual): "El servidor no funciona"
+Target (Formal): "El servidor se encuentra indisponible"
+```
+
+## Integration Notes
+
+Works well with:
+- Business Consultant persona for international communication
+- Creative Writer persona for transcreation
+- Technical Analyst for documentation translation
+- Customer Service agents for multilingual support


### PR DESCRIPTION
## Summary
This PR adds 7 default skills to the collection as part of the v1.3.0 release, cherry-picked from PR #80 without the workflow changes.

## Context
- Original large PR: #73 (being split into smaller PRs)
- Previous attempt: #80 (included unwanted workflow changes)
- This PR contains **only the skill files**, preserving the claude-review workflow from PR #90

## What's Added

### 🛠️ Skills (7)
- `code-review` - Systematic code quality analysis
- `creative-writing` - Creative content generation
- `data-analysis` - Data interpretation and insights
- `penetration-testing` - Security vulnerability testing
- `research` - Comprehensive research capabilities
- `threat-modeling` - Security threat assessment
- `translation` - Multi-language translation

## Key Differences from PR #80
- ❌ **Excluded**: All workflow changes (`.github/workflows/*`)
- ❌ **Excluded**: `CLAUDE_STATUS_CHECK_SETUP.md`
- ❌ **Excluded**: Changes to `src/validators/security-patterns.ts`
- ✅ **Included**: Only the 7 skill files + minor update to debugging-assistant.md

## Testing
- ✅ All 191 security tests pass
- ✅ Content validation passes
- ✅ No workflow conflicts

## Next Steps
After this PR is merged, we can:
1. Close PR #80 (superseded by this PR)
2. Continue with the remaining parts of PR #73 split

@claude please review this PR focusing on the skill content quality and metadata compliance.