### PR TITLE
Make category optional in content validator for flat directory structure

### DIFF
--- a/src/validators/content-validator.ts
+++ b/src/validators/content-validator.ts
@@ -30,7 +30,7 @@ const BaseMetadataSchema = z.object({
   description: z.string().min(10).max(500),
   unique_id: z.string().regex(/^[a-z0-9-_]+$/),
   author: z.string().min(2).max(100),
-  category: z.enum(['creative', 'educational', 'gaming', 'personal', 'professional']),
+  category: z.enum(['creative', 'educational', 'gaming', 'personal', 'professional']).optional(),
   version: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
   created_date: z.union([z.string(), z.date()]).optional(),
   updated_date: z.union([z.string(), z.date()]).optional(),

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -30,7 +30,6 @@ export default async function globalSetup() {
     
     for (const type of contentTypes) {
       await mkdir(join(testLibraryDir, type), { recursive: true });
-      await mkdir(join(testLibraryDir, type, 'test-category'), { recursive: true });
     }
     
     // Create test fixture files
@@ -103,7 +102,7 @@ async function createTestFixtures(libraryDir: string) {
   ];
   
   for (const fixture of fixtures) {
-    const filePath = join(libraryDir, fixture.type, fixture.category, fixture.filename);
+    const filePath = join(libraryDir, fixture.type, fixture.filename);
     await writeFile(filePath, fixture.content, 'utf8');
   }
 }
@@ -114,6 +113,7 @@ unique_id: test-persona-integration
 name: Test Persona for Integration
 description: A test persona used for integration testing
 type: persona
+category: test-category
 version: 1.0.0
 tags:
   - test
@@ -148,6 +148,7 @@ unique_id: test-skill-integration
 name: Test Skill for Integration
 description: A test skill used for integration testing
 type: skill
+category: test-category
 version: 1.0.0
 tags:
   - test
@@ -183,6 +184,7 @@ unique_id: test-agent-integration
 name: Test Agent for Integration
 description: A test agent used for integration testing
 type: agent
+category: test-category
 version: 1.0.0
 tags:
   - test
@@ -221,12 +223,12 @@ unique_id: test-prompt-integration
 name: Test Prompt for Integration
 description: A test prompt used for integration testing
 type: prompt
+category: test-category
 version: 1.0.0
 tags:
   - test
   - integration
   - validation
-category: testing
 use_case: integration-testing
 author: Test Suite
 created_at: ${new Date().toISOString()}
@@ -259,12 +261,12 @@ unique_id: test-template-integration
 name: Test Template for Integration
 description: A test template used for integration testing
 type: template
+category: test-category
 version: 1.0.0
 tags:
   - test
   - integration
   - template
-category: testing
 variables:
   - test_name
   - test_scenario
@@ -306,12 +308,12 @@ unique_id: test-tool-integration
 name: Test Tool for Integration
 description: A test tool used for integration testing
 type: tool
+category: test-category
 version: 1.0.0
 tags:
   - test
   - integration
   - utility
-category: testing
 interfaces:
   - cli
   - api
@@ -354,6 +356,7 @@ unique_id: test-ensemble-integration
 name: Test Ensemble for Integration
 description: A test ensemble combining multiple components for integration testing
 type: ensemble
+category: test-category
 version: 1.0.0
 tags:
   - test


### PR DESCRIPTION
## Summary
This PR updates the content validator to make the category field optional, enabling the transition to a flat directory structure while maintaining backward compatibility.

## Changes
- Updated `BaseMetadataSchema` in `content-validator.ts` to make category field optional
- Modified test setup to create flat directory structure without category subdirectories
- Updated file paths in test fixtures to use flat structure
- Kept category in metadata for backward compatibility

## Context
This is Phase 1 of the category removal plan outlined in the DollhouseMCP repository. The goal is to transition from:
- `library/{type}/{category}/{file}.md` 
- To: `library/{type}/{file}.md`

## Testing
- ✅ All unit tests passing (90 tests)
- ✅ All integration tests passing (32 tests)
- ✅ Backward compatibility maintained - existing content with categories still validates

## Related to
- DollhouseMCP repository's category removal initiative
- All schemas already have `.passthrough()` from PR #73 for forward compatibility