### PR TITLE
Fix Claude review workflow - duplicate 'core' declaration

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -136,8 +136,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
-            
             // Wait a moment to ensure Claude's comments are posted
             await new Promise(resolve => setTimeout(resolve, 3000));
             


### PR DESCRIPTION
## Summary
This PR fixes a JavaScript error in the Claude review workflow that was causing PR checks to fail even when Claude approved the PR.

## Problem
The workflow was failing with:
```
SyntaxError: Identifier 'core' has already been declared
```

## Root Cause
The github-script action already provides `core` as a global variable, but the workflow script was trying to require it again on line 139.

## Solution
Removed the duplicate declaration:
```diff
- const core = require('@actions/core');
```

## Testing
- The `core` object is still available for use in `core.setFailed()` on line 196
- This fix will prevent the workflow from crashing when creating PR reviews

## Impact
- PR checks will now correctly reflect Claude's review status
- No more confusing failed checks when Claude approves
- Branch protection will work as intended

Fixes #95