### PR TITLE
Fix workflow path filtering to prevent stuck pending checks

### DIFF
--- a/.github/workflows/content-security-validation.yml
+++ b/.github/workflows/content-security-validation.yml
@@ -2,16 +2,8 @@ name: Content Security Validation
 
 on:
   pull_request:
-    paths:
-      - 'library/**/*.md'
-      - 'showcase/**/*.md'
-      - 'catalog/**/*.md'
   push:
     branches: [main]
-    paths:
-      - 'library/**/*.md'
-      - 'showcase/**/*.md'
-      - 'catalog/**/*.md'
   workflow_dispatch:
     inputs:
       content_path:
@@ -57,7 +49,18 @@ jobs:
             catalog/**/*.md
           separator: ','
       
+      - name: Check if validation needed
+        id: check-needed
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ -z "${{ steps.changed-files.outputs.all_changed_files }}" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No content files changed, skipping validation"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+      
       - name: Validate changed content
+        if: steps.check-needed.outputs.skip != 'true'
         id: validate
         shell: bash
         run: |
@@ -95,7 +98,7 @@ jobs:
           fi
       
       - name: Generate security report
-        if: always()
+        if: always() && steps.check-needed.outputs.skip != 'true'
         id: report
         shell: bash
         run: |
@@ -150,8 +153,8 @@ jobs:
             echo "markdown=No validation report generated" >> $GITHUB_OUTPUT
           fi
       
-      - name: Comment PR with results
-        if: github.event_name == 'pull_request'
+      - name: Comment PR with results (validation performed)
+        if: github.event_name == 'pull_request' && steps.check-needed.outputs.skip != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -203,11 +206,33 @@ jobs:
       - name: Set status check
         if: github.event_name == 'pull_request'
         run: |
-          if [ "${{ steps.validate.outputs.validation_passed }}" != "true" ]; then
+          if [ "${{ steps.check-needed.outputs.skip }}" == "true" ]; then
+            echo "✅ Content security validation skipped - no content files changed"
+          elif [ "${{ steps.validate.outputs.validation_passed }}" != "true" ]; then
             echo "❌ Content security validation failed. Please review the security report above."
             exit 1
+          else
+            echo "✅ Content security validation passed!"
           fi
-          echo "✅ Content security validation passed!"
+      
+      - name: Comment PR with skip notice
+        if: github.event_name == 'pull_request' && steps.check-needed.outputs.skip == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `## 🔒 Content Security Scan Results
+            
+            ### ✅ Security Scan Skipped
+            
+            No content files (library/showcase/catalog) were modified in this PR, so security validation was skipped.
+            `;
+            
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
       
       - name: Upload security report
         if: always()

--- a/.github/workflows/validate-content.yml
+++ b/.github/workflows/validate-content.yml
@@ -2,16 +2,8 @@ name: Validate Content
 
 on:
   pull_request:
-    paths:
-      - 'library/**/*.md'
-      - 'showcase/**/*.md'
-      - 'catalog/**/*.md'
   push:
     branches: [main]
-    paths:
-      - 'library/**/*.md'
-      - 'showcase/**/*.md'
-      - 'catalog/**/*.md'
   workflow_dispatch:
 
 permissions:
@@ -51,11 +43,51 @@ jobs:
             catalog/**/*.md
           separator: ' '
       
+      - name: Check if validation needed
+        id: check-needed
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && [[ -z "${{ steps.changed-files.outputs.all_changed_files }}" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No content files changed, skipping validation"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+      
       - name: Validate changed files
-        if: steps.changed-files.outputs.all_changed_files != ''
+        if: steps.changed-files.outputs.all_changed_files != '' && steps.check-needed.outputs.skip != 'true'
         run: |
           echo "Validating changed files..."
           node dist/src/cli/validate-content.js ${{ steps.changed-files.outputs.all_changed_files }}
+      
+      - name: Comment PR when skipped
+        if: github.event_name == 'pull_request' && steps.check-needed.outputs.skip == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `## 🔍 Content Validation Report
+            
+            ✅ **Validation Skipped**
+            
+            No content files (library/showcase/catalog) were modified in this PR, so content validation was skipped.`;
+            
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+      
+      - name: Set status
+        if: always()
+        run: |
+          if [[ "${{ steps.check-needed.outputs.skip }}" == "true" ]]; then
+            echo "✅ Content validation skipped - no content files changed"
+          elif [[ "${{ job.status }}" == "success" ]]; then
+            echo "✅ Content validation passed!"
+          else
+            echo "❌ Content validation failed"
+            exit 1
+          fi
       
       - name: Comment PR with results
         if: failure() && github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
This PR improves the Security Validation and Validate Content workflows to prevent them from being stuck in 'pending' state on PRs that don't modify content files.

## Problem
- Both workflows had path filtering that prevented them from running on non-content PRs
- GitHub branch protection requires these checks but doesn't understand when they're skipped
- This caused PRs like #96 (workflow-only changes) to have perpetually pending checks

## Solution
Updated both workflows to:
1. Always run on all PRs (removed path filters from triggers)
2. Check if any relevant content files changed
3. Skip validation steps when no content files are modified
4. Report success and post a comment explaining the skip

## Changes Made

### Security Validation Workflow
- Removed path filters from `on:` triggers
- Added `check-needed` step to detect if content files changed
- Skip validation steps when `skip=true`
- Post comment when validation is skipped
- Always exit successfully when no content to validate

### Validate Content Workflow
- Same pattern as above
- Simpler workflow so fewer changes needed

## Testing
- Workflows will now run on this PR
- They should detect no content files changed
- Should post skip comments and exit successfully
- All checks should be green, not pending

## Example Output
When no content files are changed, PRs will see:
```
## 🔒 Content Security Scan Results

### ✅ Security Scan Skipped

No content files (library/showcase/catalog) were modified in this PR, so security validation was skipped.
```

Fixes #97