### PR TITLE
chore: configure Dependabot to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -24,6 +25,7 @@ updates:
   # Monitor GitHub Actions for security updates
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary
Updates Dependabot configuration to create PRs against the develop branch instead of main, aligning with our GitOps workflow.

## Changes
- Added `target-branch: "develop"` to npm package ecosystem configuration
- Added `target-branch: "develop"` to GitHub Actions ecosystem configuration

## Rationale
Per our GitOps workflow established in Issue #131:
- All changes should go through develop branch first
- Feature branches merge to develop
- Only develop, release/*, and hotfix/* merge to main
- This prevents Dependabot from violating our branch protection rules

## Impact
- Future Dependabot PRs will target develop branch
- Dependency updates will follow the same workflow as feature development
- Better alignment with GitFlow best practices

## Testing
The configuration has been validated against the Dependabot schema.

## Related Issues
- Part of Issue #131 (Update GitFlow Guardian and handle Dependabot for GitOps workflow)
- Follows up on PR #134 (Node.js 22 upgrade)