### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollhousemcp/collection",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DollhouseMCP Collection - The official collection of AI content including personas, skills, agents, prompts, templates, tools, and ensembles",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bumping version for point release v1.0.1

This should be merged to develop before the develop→main merge.