### PR TITLE
fix: Extract element type from issue title in submission workflow

### DIFF
--- a/.github/workflows/process-element-submission.yml
+++ b/.github/workflows/process-element-submission.yml
@@ -195,6 +195,28 @@ jobs:
 
             log(`✅ Metadata extracted with ${Object.keys(metadata).length} fields`);
 
+            // Extract type from issue title if not present in metadata
+            // Issue title format: [type] Add element-name by @username
+            if (!metadata.type) {
+              const titleMatch = issueTitle.match(/^\[([^\]]+)\]/);
+              if (titleMatch) {
+                // Convert plural to singular (personas -> persona, etc.)
+                const typeFromTitle = titleMatch[1].toLowerCase();
+                const typeMap = {
+                  'personas': 'persona',
+                  'skills': 'skill',
+                  'agents': 'agent',
+                  'prompts': 'prompt',
+                  'templates': 'template',
+                  'tools': 'tool',
+                  'ensembles': 'ensemble',
+                  'memories': 'memory'
+                };
+                metadata.type = typeMap[typeFromTitle] || typeFromTitle;
+                log(`✅ Extracted type from issue title: ${metadata.type}`);
+              }
+            }
+
             // Validate required fields
             const requiredFields = ['name', 'description', 'unique_id', 'author', 'type'];
             for (const field of requiredFields) {
@@ -268,7 +290,20 @@ jobs:
             const elementType = metadata.type;
             const category = metadata.category || 'personal';
             const filename = metadata.unique_id.replace(/[^a-z0-9-_]/g, '-') + '.md';
-            const targetPath = `library/${elementType}s/${filename}`;
+            
+            // Map singular types to plural directory names
+            const dirMap = {
+              'persona': 'personas',
+              'skill': 'skills',
+              'agent': 'agents',
+              'prompt': 'prompts',
+              'template': 'templates',
+              'tool': 'tools',
+              'ensemble': 'ensembles',
+              'memory': 'memories'
+            };
+            const targetDir = dirMap[elementType] || `${elementType}s`;
+            const targetPath = `library/${targetDir}/${filename}`;
             
             // Save validation results
             const validationResult = {


### PR DESCRIPTION
## Summary
Fixes the workflow validation error where it expected a 'type' field that wasn't provided by MCP server submissions.

## Problem
The workflow required a 'type' field in the element metadata, but MCP server submissions don't include this field. The element type is provided in the issue title format: `[personas] Add element-name by @username`

This caused all submissions to fail with: `Error: Missing required field: type`

## Solution
1. **Extract type from issue title** - When 'type' is not in metadata, parse it from the issue title
2. **Convert plural to singular** - Map 'personas' → 'persona', 'skills' → 'skill', etc.
3. **Fix directory mapping** - Properly map singular types to plural directory names
4. **Support all element types** - Handle all 8 element types correctly

## Testing
The fix will automatically work with existing submissions:
- Issue #151: august-28th-test
- Issue #152: august-28-fix-test

## Impact
- Unblocks the collection submission pipeline
- Allows MCP server submissions with full content to be processed
- Works with the fix from MCP server PR #818

## Related Issues
- Fixes validation failures for Issues #151, #152
- Works in conjunction with MCP server PR #818

🤖 Generated with Claude Code