### PR TITLE
fix: Use issue submitter as PR assignee instead of repository owner

### DIFF
--- a/.github/workflows/process-element-submission.yml
+++ b/.github/workflows/process-element-submission.yml
@@ -424,7 +424,7 @@ jobs:
             --title "✨ Add $ELEMENT_TYPE: $ELEMENT_NAME (from issue #$ISSUE_NUMBER)" \
             --body-file pr_body.md \
             --label "automated-submission,needs-review,$ELEMENT_TYPE" \
-            --assignee "${{ github.repository_owner }}"
+            --assignee "${{ github.event.issue.user.login }}"
 
           # Get PR number
           PR_NUMBER=$(gh pr view --json number --jq .number)


### PR DESCRIPTION
## Summary
This PR fixes the workflow failure where PRs couldn't be created because the assignee was set to 'DollhouseMCP' (an organization) instead of a valid user.

## Problem
The workflow was failing at the very last step with:
```
could not assign user: 'DollhouseMCP' not found
```

This was happening because `github.repository_owner` returns the organization name, not a user.

## Solution
Changed the assignee to use `github.event.issue.user.login` which assigns the PR to whoever submitted the element via the GitHub issue. This maintains accountability and ensures we know who submitted potentially dangerous content.

## Impact
- ✅ Workflow will complete successfully
- ✅ PRs will be assigned to the actual submitter
- ✅ Maintains accountability chain for security
- ✅ Makes it easier to track/block bad actors

## Testing
After this is merged, the next element submission should:
1. Pass all validation steps
2. Create a branch with the element file
3. Successfully create a PR assigned to the submitter
4. Complete the entire workflow without errors

🤖 Generated with [Claude Code](https://claude.ai/code)