### PR TITLE
fix: Improve example detection in integration tests

### DIFF
--- a/scripts/pr-validation/integration-tester.mjs
+++ b/scripts/pr-validation/integration-tester.mjs
@@ -745,10 +745,22 @@ class IntegrationTester {
     const contentBody = fileResult.contentBody;
     if (!contentBody) return { passed: true, message: 'No content to check', skipped: true };
 
-    // Look for example sections
-    const hasExamples = contentBody.toLowerCase().includes('example') || 
-                       contentBody.toLowerCase().includes('usage') ||
-                       contentBody.includes('```');
+    // Look for various example/usage section formats
+    const contentLower = contentBody.toLowerCase();
+    const examplePatterns = [
+      'example',           // Generic examples
+      'usage',             // Usage instructions
+      'sample',            // Sample responses/usage
+      'how to use',        // How-to sections
+      'use case',          // Use cases
+      'demonstration',     // Demonstrations
+      'illustration',      // Illustrations
+      '```'               // Code blocks (often used for examples)
+    ];
+
+    const hasExamples = examplePatterns.some(pattern =>
+      pattern === '```' ? contentBody.includes(pattern) : contentLower.includes(pattern)
+    );
 
     if (!hasExamples) {
       return {


### PR DESCRIPTION
## Summary
Updates the `examplesWorking` integration test to recognize multiple example formats, not just "example" and "usage".

## Problem
The integration test was too restrictive and failed on valid content. For example, PR #190 (travel-planner persona) had a "Sample Responses" section but the test failed because it only looked for the words "example" or "usage".

## Solution
Expanded the test to recognize these additional patterns:
- **sample** - catches "Sample Responses", "Sample Usage", etc.
- **use case** / **use cases** - common in documentation
- **how to use** - instructional sections
- **demonstration** - demo sections
- **illustration** - illustrative examples

## Testing
- Manually verified against travel-planner persona (now passes)
- All existing tests should continue to pass
- No breaking changes - only additive patterns

## Related
- Fixes false positive in PR #190
- Improves developer experience for future submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)