### PR TITLE
fix: Make category field truly optional without enum restrictions

### DIFF
--- a/scripts/pr-validation/integration-tester.mjs
+++ b/scripts/pr-validation/integration-tester.mjs
@@ -564,23 +564,14 @@ class IntegrationTester {
   }
 
   async test_COLLECTION_INTEGRATION_validCategories(fileResult, _content) {
-    // This overlaps with enum validation but adds integration context
+    // Category is optional and can be any string value
     const metadata = fileResult.metadata;
     if (!metadata?.category) {
       return { passed: true, message: 'No category specified (optional)', skipped: true };
     }
 
-    const validCategories = ['creative', 'educational', 'gaming', 'personal', 'professional'];
-    
-    if (!validCategories.includes(metadata.category)) {
-      return {
-        passed: false,
-        message: `Invalid category for collection integration: ${metadata.category}`,
-        severity: 'medium'
-      };
-    }
-
-    return { passed: true, message: 'Category is valid for collection' };
+    // Category can be any string value - no enum restriction
+    return { passed: true, message: `Category specified: ${metadata.category}` };
   }
 
   async test_COLLECTION_INTEGRATION_properNaming(fileResult, _content) {

--- a/src/validators/content-validator.ts
+++ b/src/validators/content-validator.ts
@@ -30,7 +30,7 @@ const BaseMetadataSchema = z.object({
   description: z.string().min(10).max(500),
   unique_id: z.string().regex(/^[a-z0-9-_]+$/),
   author: z.string().min(2).max(100),
-  category: z.enum(['creative', 'educational', 'gaming', 'personal', 'professional']).optional(),
+  category: z.string().optional(),
   version: z.string().regex(/^\d+\.\d+\.\d+$/).optional(),
   created_date: z.union([z.string(), z.date()]).optional(),
   updated_date: z.union([z.string(), z.date()]).optional(),


### PR DESCRIPTION
## Summary
Removes overly strict category validation that was rejecting valid community-contributed content.

## Problem
The validator was enforcing a strict enum for the `category` field, rejecting any value outside of:
- creative
- educational  
- gaming
- personal
- professional

This was causing false positives on PRs #213-216 where community content had custom category values like "general".

## Solution
Made `category` truly optional and removed enum restrictions:

### 1. **content-validator.ts** - Accept any string value
```typescript
// Before
category: z.enum(['creative', 'educational', 'gaming', 'personal', 'professional']).optional()

// After  
category: z.string().optional()
```

### 2. **integration-tester.mjs** - Remove category validation
- Test now accepts any string value for category
- Still skips if category is not present (remains optional)
- No longer fails for non-enum values

## Impact
- ✅ Category field remains optional (can be omitted)
- ✅ Category accepts any string value if present
- ✅ Fixes false positives in PRs #213-216
- ✅ Enables community-contributed content with custom categories
- ✅ No breaking changes - all existing valid content still passes

## Testing
- Existing tests updated to reflect new validation logic
- All type-safe - TypeScript compilation succeeds
- No impact on other validation rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)