### PR TITLE
Security hotfix: remove pull_request_target from pr-validation.yml

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,11 +12,10 @@ on:
 # fork code, enabling pwn request attacks. See DollhouseMCP/collection#227.
 # Contributions go via the issue submission form, not fork PRs, so this is acceptable.
 # Internal branch PRs still get full validation via pull_request trigger above.
-permissions:
-  contents: read
-  pull-requests: read
-  checks: read
-  statuses: read
+#
+# Permissions are set per-job (not workflow-level) to minimize blast radius.
+# Default token has no permissions unless explicitly granted below.
+permissions: {}
 
 env:
   NODE_VERSION: '20'
@@ -25,6 +24,9 @@ jobs:
   security-scan:
     name: Security Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       security-passed: ${{ steps.scan.outputs.passed }}
       security-score: ${{ steps.scan.outputs.score }}
@@ -98,6 +100,9 @@ jobs:
   schema-check:
     name: Schema Validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       schema-passed: ${{ steps.validate.outputs.passed }}
       schema-errors: ${{ steps.validate.outputs.errors }}
@@ -168,6 +173,9 @@ jobs:
   content-quality:
     name: Content Quality Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       quality-passed: ${{ steps.analyze.outputs.passed }}
       quality-score: ${{ steps.analyze.outputs.score }}
@@ -242,6 +250,9 @@ jobs:
   integration-test:
     name: Integration Testing
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     outputs:
       integration-passed: ${{ steps.test.outputs.passed }}
       integration-report: ${{ steps.test.outputs.report }}
@@ -318,7 +329,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [security-scan, schema-check, content-quality, integration-test]
     if: always()
-    
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Security hotfix for the pwn request vulnerability in `pr-validation.yml`. Identical fix to PR #230 (already merged to `develop`), now applied to `main`.

- Removes `pull_request_target` trigger (elevated GITHUB_TOKEN + fork code = pwn request attack vector)
- Per-job `permissions:` with deny-all default at workflow level
- Removes explicit `ref: ${{ github.event.pull_request.head.sha }}` (SonarCloud SAST fix)

## Why a separate hotfix

`main` has a divergent commit (`travel-planner` persona added directly) that prevents a clean develop→main merge. This hotfix cherry-picks only the 3 security commits from the `hotfix/pwn-request-fix` branch.

Fixes: #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)