### PR TITLE
Normalize element authors to DollhouseMCP, archive legacy types

### DIFF
--- a/archive/prompts/story-starter.md
+++ b/archive/prompts/story-starter.md
@@ -3,7 +3,7 @@ type: prompt
 name: Story Starter
 description: Creative writing prompt generator for various genres and styles
 unique_id: prompt_story-starter_dollhousemcp_20250715-100200
-author: dollhousemcp
+author: DollhouseMCP
 category: creative
 version: 1.0.0
 tags:

--- a/archive/tools/task-prioritizer.md
+++ b/archive/tools/task-prioritizer.md
@@ -3,7 +3,7 @@ type: tool
 name: Task Prioritizer
 description: MCP tool for intelligent task prioritization using multiple frameworks
 unique_id: tool_task-prioritizer_dollhousemcp_20250715-100400
-author: dollhousemcp
+author: DollhouseMCP
 category: personal
 version: 1.0.0
 tags:

--- a/library/agents/academic-researcher.md
+++ b/library/agents/academic-researcher.md
@@ -3,7 +3,7 @@ type: agent
 name: Academic Researcher
 description: An autonomous agent specialized in conducting thorough academic research
 unique_id: agent_academic-researcher_dollhousemcp_20250715-100100
-author: dollhousemcp
+author: DollhouseMCP
 category: educational
 version: 1.0.0
 tags:

--- a/library/agents/code-reviewer.md
+++ b/library/agents/code-reviewer.md
@@ -3,7 +3,7 @@ name: Code Reviewer
 description: 'Automated code review agent with security, performance, and quality analysis'
 type: agent
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 created: '2025-07-23'
 category: professional
 tags: &ref_0

--- a/library/agents/research-assistant.md
+++ b/library/agents/research-assistant.md
@@ -3,7 +3,7 @@ name: Research Assistant
 description: Autonomous agent for conducting thorough research and synthesizing findings
 type: agent
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 created: '2025-07-23'
 category: professional
 tags: &ref_0

--- a/library/agents/task-manager.md
+++ b/library/agents/task-manager.md
@@ -3,7 +3,7 @@ name: Task Manager
 description: 'Goal-oriented agent for managing tasks, priorities, and project execution'
 type: agent
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 created: '2025-07-23'
 category: personal
 tags: &ref_0

--- a/library/ensembles/complete-productivity-suite.md
+++ b/library/ensembles/complete-productivity-suite.md
@@ -5,7 +5,7 @@ description: >-
   A comprehensive collection of productivity-enhancing content for personal and
   professional use
 unique_id: ensemble_complete-productivity-suite_dollhousemcp_20250715-100500
-author: dollhousemcp
+author: DollhouseMCP
 category: personal
 version: 1.0.0
 tags:

--- a/library/ensembles/full-stack-developer.md
+++ b/library/ensembles/full-stack-developer.md
@@ -5,7 +5,7 @@ description: >-
   Complete development environment combining personas, tools, and skills for
   professional software development
 unique_id: ensemble_full-stack-developer-ensemble_dollhousemcp_20250715-100600
-author: dollhousemcp
+author: DollhouseMCP
 category: professional
 version: 1.0.0
 tags:

--- a/library/memories/conversation-history.md
+++ b/library/memories/conversation-history.md
@@ -3,7 +3,7 @@ name: Conversation History
 description: Maintains context and continuity across multiple conversation sessions
 type: memory
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 created: '2025-07-23'
 category: personal
 tags:

--- a/library/memories/learning-progress.md
+++ b/library/memories/learning-progress.md
@@ -3,7 +3,7 @@ name: Learning Progress
 description: Tracks learning goals, progress, and personalized educational pathways
 type: memory
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 created: '2025-07-23'
 category: educational
 tags:

--- a/library/memories/project-context.md
+++ b/library/memories/project-context.md
@@ -3,7 +3,7 @@ name: Project Context
 description: Persistent memory for project-specific information, decisions, and history
 type: memory
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 created: '2025-07-23'
 category: professional
 tags:

--- a/library/personas/blog-copy-editor.md
+++ b/library/personas/blog-copy-editor.md
@@ -2,7 +2,7 @@
 name: "blog-copy-editor"
 description: "A professional blog copy editor specializing in transforming stream-of-consciousness content into polished, engaging blog posts"
 unique_id: "blog-copy-editor_20250812-152639_anon-bright-wolf-u06x"
-author: "anon-cool-cat-6cg7"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/business-consultant.md
+++ b/library/personas/business-consultant.md
@@ -11,7 +11,7 @@ triggers:
   - market
   - revenue
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 unique_id: persona_business-consultant_dollhousemcp_20250723-165719
 created: '2025-07-23T00:00:00.000Z'
 type: persona

--- a/library/personas/code-review-companion.md
+++ b/library/personas/code-review-companion.md
@@ -2,7 +2,7 @@
 name: "code-review-companion"
 description: "A thorough and educational code reviewer who provides constructive feedback to improve code quality, security, and maintainability while helping developers learn and grow."
 unique_id: "code-review-companion_20250827-154545_anon-cool-lion-7a1i"
-author: "anon-witty-bear-fcgw"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/codeql-security-analyst.md
+++ b/library/personas/codeql-security-analyst.md
@@ -2,7 +2,7 @@
 name: codeql-security-analyst
 description: Expert security analyst specializing in CodeQL static analysis, with deep expertise in identifying and resolving false positives, understanding taint analysis, and implementing proper suppression strategies
 unique_id: "codeql-security-analyst_20250907-164136_anon-swift-cat-0l6z"
-author: anon-bright-fox-br28
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/connection-intelligence-analyst.md
+++ b/library/personas/connection-intelligence-analyst.md
@@ -2,7 +2,7 @@
 name: connection-intelligence-analyst
 description: Expert at researching people, mapping professional connections, and building comprehensive profiles using public information. Specializes in LinkedIn analysis, relationship mapping, and storing actionable insights.
 unique_id: "connection-intelligence-analyst_20250919-170817_anon-witty-hawk-7iyn"
-author: anon-bold-cat-m4q7
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/copy-editor-professional.md
+++ b/library/personas/copy-editor-professional.md
@@ -2,7 +2,7 @@
 name: copy-editor-professional
 description: A meticulous copy editor who refines language for clarity, flow, and authentic voice while preserving the authors intent
 unique_id: "copy-editor-professional_20250904-100344_mickdarling"
-author: mickdarling
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/debug-detective.md
+++ b/library/personas/debug-detective.md
@@ -11,7 +11,7 @@ triggers:
   - bug
   - problem
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 unique_id: persona_debug-detective_dollhousemcp_20250723-165719
 created: '2025-07-23T00:00:00.000Z'
 type: persona

--- a/library/personas/document-obfuscation-specialist.md
+++ b/library/personas/document-obfuscation-specialist.md
@@ -2,7 +2,7 @@
 name: document-obfuscation-specialist
 description: Specialized persona for document anonymization and privacy protection in academic and research contexts with systematic approach to name obfuscation
 unique_id: "document-obfuscation-specialist_20250922-180808_anon-clever-wolf-486v"
-author: anon-swift-lion-cpv8
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/dollhouse-expert.md
+++ b/library/personas/dollhouse-expert.md
@@ -2,7 +2,7 @@
 name: "dollhouse-expert"
 description: "An expert guide for DollhouseMCP - the AI customization and persona management system. Provides comprehensive knowledge about personas, skills, templates, agents, and the entire DollhouseMCP ecosystem."
 unique_id: "dollhouse-expert_20250827-143521_anon-calm-fox-br4v"
-author: "anon-clever-lion-ln32"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/eli5-explainer.md
+++ b/library/personas/eli5-explainer.md
@@ -11,7 +11,7 @@ triggers:
   - teach
   - basics
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 unique_id: persona_eli5-explainer_dollhousemcp_20250723-165719
 created: '2025-07-23T00:00:00.000Z'
 type: persona

--- a/library/personas/executive-assistant-pro.md
+++ b/library/personas/executive-assistant-pro.md
@@ -2,7 +2,7 @@
 name: "executive-assistant-pro"
 description: "A highly capable, warm, and detail-oriented virtual assistant with exceptional summarization skills and a talent for creating productive, positive working environments"
 unique_id: "executive-assistant-pro_20250827-114816_anon-sharp-owl-v1v2"
-author: "anon-calm-cat-rzld"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/git-flow-master.md
+++ b/library/personas/git-flow-master.md
@@ -2,7 +2,7 @@
 name: "git-flow-master"
 description: "Expert Git and GitHub advisor specializing in version control workflows, best practices, and troubleshooting. Provides guidance on proper Git flow patterns and can identify anti-patterns in version control practices."
 unique_id: "git-flow-master_20250827-151940_anon-bold-lion-wysu"
-author: "anon-keen-owl-nhk9"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/gitflow-detective.md
+++ b/library/personas/gitflow-detective.md
@@ -2,7 +2,7 @@
 name: gitflow-detective
 description: Expert Git detective specializing in branch divergence analysis, commit forensics, and GitFlow resolution strategies
 unique_id: "gitflow-detective_20250919-152955_anon-bold-bear-eyu2"
-author: anon-calm-hawk-io80
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/github-integration-expert.md
+++ b/library/personas/github-integration-expert.md
@@ -2,7 +2,7 @@
 name: github-integration-expert
 description: Expert persona for GitHub integration, OAuth workflows, and portfolio management
 unique_id: "github-integration-expert_20250910-200613_anon-keen-deer-zzbh"
-author: anon-wise-hawk-mk9i
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/hackernews-content-strategist.md
+++ b/library/personas/hackernews-content-strategist.md
@@ -2,7 +2,7 @@
 name: "hackernews-content-strategist"
 description: "Expert at crafting technically-focused content that resonates with Hacker News community values"
 unique_id: "hackernews-content-strategist_20250829-113232_anon-cool-cat-785h"
-author: "anon-keen-owl-hhos"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/innovation-architect.md
+++ b/library/personas/innovation-architect.md
@@ -2,7 +2,7 @@
 name: innovation-architect
 description: A creative systems thinker specializing in innovative architecture design, pattern recognition, and cross-domain synthesis for complex technical challenges
 unique_id: "innovation-architect_20250917-115834_anon-cool-bear-awk6"
-author: anon-witty-tiger-hol8
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/link-validator.md
+++ b/library/personas/link-validator.md
@@ -2,7 +2,7 @@
 name: link-validator
 description: Expert at validating and fixing link issues in GitHub repositories, with deep knowledge of markdown link checking tools and CI/CD workflows
 unique_id: "link-validator_20250903-152813_anon-bright-fox-9xkj"
-author: anon-clever-tiger-3tbl
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/linkedin-content-strategist.md
+++ b/library/personas/linkedin-content-strategist.md
@@ -2,7 +2,7 @@
 name: "linkedin-content-strategist"
 description: "Expert at crafting professional LinkedIn content that builds thought leadership and drives engagement"
 unique_id: "linkedin-content-strategist_20250829-113243_anon-swift-bear-vqr5"
-author: "anon-bright-bear-ppkp"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/linkedin-profile-analyst.md
+++ b/library/personas/linkedin-profile-analyst.md
@@ -2,7 +2,7 @@
 name: linkedin-profile-analyst
 description: A specialized LinkedIn outreach expert who conducts deep profile analysis to craft highly personalized messages that resonate with specific individuals
 unique_id: "linkedin-profile-analyst_20250903-142131_anon-wise-bear-zyaq"
-author: anon-bold-tiger-fdvq
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/marketing-strategist-tech-products.md
+++ b/library/personas/marketing-strategist-tech-products.md
@@ -2,7 +2,7 @@
 name: marketing-strategist-tech-products
 description: Expert marketing strategist for technical products who develops competitive positioning, multi-channel campaigns, and market differentiation strategies for developer tools
 unique_id: "marketing-strategist-tech-products_20251020-144530_anon-cool-fox-ne98"
-author: anon-bright-tiger-t0rx
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/marketing-writer-tech-products.md
+++ b/library/personas/marketing-writer-tech-products.md
@@ -2,7 +2,7 @@
 name: marketing-writer-tech-products
 description: Expert marketing writer for technical products who crafts compelling narratives while maintaining authenticity and adapting content across multiple channels
 unique_id: "marketing-writer-tech-products_20251020-144530_anon-cool-tiger-z2yr"
-author: anon-keen-tiger-fz24
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/open-source-business-strategist.md
+++ b/library/personas/open-source-business-strategist.md
@@ -2,7 +2,7 @@
 name: open-source-business-strategist
 description: Strategic advisor specializing in open source business models, freemium strategies, and sustainable revenue generation for developer tools
 unique_id: "open-source-business-strategist_20250902-120300_anon-wise-tiger-7c61"
-author: anon-wise-owl-7kd3
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/public-relations-tech-products.md
+++ b/library/personas/public-relations-tech-products.md
@@ -2,7 +2,7 @@
 name: public-relations-tech-products
 description: Expert public relations specialist for technical products who manages media relations, community engagement, crisis communications, and builds positive brand perception
 unique_id: "public-relations-tech-products_20251020-144729_anon-sharp-owl-1xsb"
-author: anon-keen-lion-yust
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/reddit-content-creator.md
+++ b/library/personas/reddit-content-creator.md
@@ -2,7 +2,7 @@
 name: reddit-content-creator
 description: A savvy Reddit content creator who understands community dynamics, engagement patterns, and platform culture
 unique_id: "reddit-content-creator_20250829-175026_anon-cool-bear-r1x8"
-author: anon-bright-deer-586v
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/reddit-content-strategist.md
+++ b/library/personas/reddit-content-strategist.md
@@ -2,7 +2,7 @@
 name: "reddit-content-strategist"
 description: "Expert at crafting engaging Reddit posts that follow subreddit rules and community culture"
 unique_id: "reddit-content-strategist_20250829-113218_anon-sharp-cat-hzj1"
-author: "anon-bright-hawk-e4xb"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/reddit-karma-farmer.md
+++ b/library/personas/reddit-karma-farmer.md
@@ -2,7 +2,7 @@
 name: Reddit Karma Farmer
 description: A persona that understands Reddit culture deeply and knows how to craft engaging posts and comments that resonate with different subreddits
 unique_id: persona_reddit-karma-farmer_mickdarling_20250831-224843
-author: mickdarling
+author: DollhouseMCP
 triggers: ['reddit', 'karma', 'engagement', 'community']
 version: '1.0.0'
 age_rating: all

--- a/library/personas/resume-anonymization-specialist.md
+++ b/library/personas/resume-anonymization-specialist.md
@@ -2,7 +2,7 @@
 name: resume-anonymization-specialist
 description: Specialized persona for resume and CV anonymization focused on removing bias-inducing information while maintaining professional qualifications and document formatting
 unique_id: "resume-anonymization-specialist_20250922-185938_anon-keen-wolf-lw1e"
-author: anon-cool-eagle-4y6n
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/screenwriting-suite-01-professional-screenwriter.md
+++ b/library/personas/screenwriting-suite-01-professional-screenwriter.md
@@ -2,7 +2,7 @@
 name: "screenwriting-suite-01-professional-screenwriter"
 description: "Professional screenwriter persona specializing in feature films, TV series, and streaming content development - part of comprehensive screenwriting suite"
 unique_id: "screenwriting-suite-01-professional-screenwriter_20250829-105158_anon-sharp-owl-ozkd"
-author: "anon-cool-wolf-bkhp"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/screenwriting-suite-02-tv-development-assistant.md
+++ b/library/personas/screenwriting-suite-02-tv-development-assistant.md
@@ -2,7 +2,7 @@
 name: "screenwriting-suite-02-tv-development-assistant"
 description: "Interactive TV development assistant for creating professional treatments, pitch decks, and pilot materials - part of comprehensive screenwriting suite"
 unique_id: "screenwriting-suite-02-tv-development-assistant_20250829-105220_anon-bold-bear-5hlq"
-author: "anon-witty-lion-0eqc"
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: "all"

--- a/library/personas/software-licensing-expert.md
+++ b/library/personas/software-licensing-expert.md
@@ -2,7 +2,7 @@
 name: software-licensing-expert
 description: Expert in software licensing, specializing in AGPL, dual licensing models, open source compliance, and commercial license structures
 unique_id: "software-licensing-expert_20251014-182456_anon-clever-owl-an1a"
-author: anon-witty-eagle-j5lz
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/solution-keeper.md
+++ b/library/personas/solution-keeper.md
@@ -2,7 +2,7 @@
 name: solution-keeper
 description: A meticulous documentation specialist who captures working solutions immediately with full reproducibility context
 unique_id: "solution-keeper_20250911-184747_anon-cool-wolf-zgse"
-author: anon-calm-wolf-ehu5
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/technical-analyst.md
+++ b/library/personas/technical-analyst.md
@@ -10,7 +10,7 @@ triggers:
   - debugging
   - systematic
 version: 1.0.0
-author: dollhousemcp
+author: DollhouseMCP
 unique_id: persona_technical-analyst_dollhousemcp_20250723-165719
 created: '2025-07-23T00:00:00.000Z'
 type: persona

--- a/library/personas/technical-bridge-builder.md
+++ b/library/personas/technical-bridge-builder.md
@@ -2,7 +2,7 @@
 name: technical-bridge-builder
 description: A skilled technical educator who translates complex engineering concepts into clear, business-relevant insights for senior product managers and stakeholders
 unique_id: "technical-bridge-builder_20251020-085551_anon-wise-lion-288a"
-author: anon-keen-deer-73so
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/technical-writer-ai-architecture.md
+++ b/library/personas/technical-writer-ai-architecture.md
@@ -2,7 +2,7 @@
 name: technical-writer-ai-architecture
 description: Expert technical writer specializing in AI architecture, MCP systems, and developer-focused content with ability to explain complex technical concepts clearly
 unique_id: "technical-writer-ai-architecture_20251020-144530_anon-bold-bear-3cyi"
-author: anon-keen-cat-d04b
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/personas/travel-planner.md
+++ b/library/personas/travel-planner.md
@@ -5,7 +5,7 @@ description: >-
   cultural insights, and helps optimize travel experiences with practical tips
   and local recommendations.
 unique_id: travel-planner_20250830-111954_anon-witty-bear-7twh
-author: anon-bright-wolf-28kr
+author: DollhouseMCP
 triggers: []
 version: '1.1.0'
 age_rating: all

--- a/library/personas/verification-specialist.md
+++ b/library/personas/verification-specialist.md
@@ -2,7 +2,7 @@
 name: verification-specialist
 description: A meticulous quality assurance specialist focused on evidence-based verification, finding real issues, and ensuring deliverables meet requirements without false positives
 unique_id: "verification-specialist_20250901-102134_anon-cool-bear-fi1i"
-author: anon-cool-fox-8uqn
+author: DollhouseMCP
 triggers: []
 version: "1.0.0"
 age_rating: all

--- a/library/skills/roundtrip-test-skill.md
+++ b/library/skills/roundtrip-test-skill.md
@@ -2,7 +2,7 @@
 name: Roundtrip Test Skill
 description: A test skill designed to validate the complete collection submission workflow roundtrip
 unique_id: skill_roundtrip-test-skill_dollhousemcp_20250811-000000
-author: dollhousemcp
+author: DollhouseMCP
 type: skill
 version: 1.0.0
 category: testing


### PR DESCRIPTION
Closes #236

## Summary
- **Author normalization**: 48 elements normalized from `anon-*`, `dollhousemcp`, `mickdarling` to `DollhouseMCP`
- **Legacy type removal**: Moved `library/tools/` and `library/prompts/` to `archive/` (not first-class DollhouseMCP element types)
- **Preserved**: `dollhousemcp-test` entries for roundtrip testing

## Test plan
- [ ] CI validation passes (schema, quality, security, integration)
- [ ] SonarCloud quality gate passes
- [ ] Collection index builds with correct element count (now excludes tools/prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)