### PR TITLE
Add canonical lane logos; adopt collection-bluetop as site mark

### DIFF
--- a/public/dollhouse-org-brand.svg
+++ b/public/dollhouse-org-brand.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo with orange chimney">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f8ff7"></stop>
+      <stop offset="100%" stop-color="#2f6ddd"></stop>
+    </linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b5ec8"></stop>
+      <stop offset="100%" stop-color="#1f4caf"></stop>
+    </linearGradient>
+    <linearGradient id="chimneyOrange" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fb923c"></stop>
+      <stop offset="100%" stop-color="#f97316"></stop>
+    </linearGradient>
+  </defs>
+
+  
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyOrange)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#3b82f6" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#6366f1" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#7c3aed" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#a855f7" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/dollhouse-org-collection-bluetop.svg
+++ b/public/dollhouse-org-collection-bluetop.svg
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo collection — blue roof, slate base, rainbow windows">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4f8ff7"></stop><stop offset="100%" stop-color="#2f6ddd"></stop></linearGradient>
+    <linearGradient id="baseSlateCol" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#475569"></stop><stop offset="100%" stop-color="#1e293b"></stop></linearGradient>
+    <linearGradient id="chimneyColRainbow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ef4444"></stop>
+      <stop offset="33%" stop-color="#f59e0b"></stop>
+      <stop offset="66%" stop-color="#a855f7"></stop>
+      <stop offset="100%" stop-color="#ec4899"></stop>
+    </linearGradient>
+  </defs>
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyColRainbow)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#ef4444" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#f59e0b" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#22c55e" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#a855f7" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseSlateCol)"></rect>
+</svg>

--- a/public/dollhouse-org-core.svg
+++ b/public/dollhouse-org-core.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo core variant">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f8ff7"></stop>
+      <stop offset="100%" stop-color="#2f6ddd"></stop>
+    </linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b5ec8"></stop>
+      <stop offset="100%" stop-color="#1f4caf"></stop>
+    </linearGradient>
+    <linearGradient id="chimneyCore" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa"></stop>
+      <stop offset="100%" stop-color="#1e40af"></stop>
+    </linearGradient>
+  </defs>
+
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyCore)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#60a5fa" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#3b82f6" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#2563eb" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#1d4ed8" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/dollhouse-org-education-blocks.svg
+++ b/public/dollhouse-org-education-blocks.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo education variant — highlighter yellow windows">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4f8ff7"></stop><stop offset="100%" stop-color="#2f6ddd"></stop></linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#2b5ec8"></stop><stop offset="100%" stop-color="#1f4caf"></stop></linearGradient>
+    <linearGradient id="chimneyEduBlocks" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fff300"></stop><stop offset="100%" stop-color="#fde047"></stop></linearGradient>
+  </defs>
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyEduBlocks)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#fff9a8" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#fff300" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#fde047" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#facc15" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/dollhouse-org-enterprise-corner.svg
+++ b/public/dollhouse-org-enterprise-corner.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo enterprise — full slate with gold chimney and corner office">
+  <defs>
+    <linearGradient id="roofEntSlate" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#64748b"></stop><stop offset="100%" stop-color="#334155"></stop></linearGradient>
+    <linearGradient id="baseEntSlate" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#475569"></stop><stop offset="100%" stop-color="#1e293b"></stop></linearGradient>
+    <linearGradient id="chimneyEntGold2" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#e6c46a"></stop><stop offset="100%" stop-color="#8a6b1f"></stop></linearGradient>
+    <linearGradient id="cornerGold" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f1d680"></stop><stop offset="100%" stop-color="#b48a2a"></stop></linearGradient>
+  </defs>
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyEntGold2)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofEntSlate)"></path>
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#64748b"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#cbd5e1" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="url(#cornerGold)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#64748b" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#334155" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseEntSlate)"></rect>
+</svg>

--- a/public/dollhouse-org-protocol.svg
+++ b/public/dollhouse-org-protocol.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo protocol variant">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f8ff7"></stop>
+      <stop offset="100%" stop-color="#2f6ddd"></stop>
+    </linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b5ec8"></stop>
+      <stop offset="100%" stop-color="#1f4caf"></stop>
+    </linearGradient>
+    <linearGradient id="chimneyProtocol" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8"></stop>
+      <stop offset="100%" stop-color="#0e7490"></stop>
+    </linearGradient>
+  </defs>
+
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyProtocol)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#67e8f9" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#22d3ee" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#06b6d4" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#0891b2" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/dollhouse-org-research.svg
+++ b/public/dollhouse-org-research.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo research variant">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f8ff7"></stop>
+      <stop offset="100%" stop-color="#2f6ddd"></stop>
+    </linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b5ec8"></stop>
+      <stop offset="100%" stop-color="#1f4caf"></stop>
+    </linearGradient>
+    <linearGradient id="chimneyResearch" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e879f9"></stop>
+      <stop offset="100%" stop-color="#a21caf"></stop>
+    </linearGradient>
+  </defs>
+
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyResearch)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#f0abfc" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#e879f9" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#c026d3" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#a21caf" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/dollhouse-org-security-red.svg
+++ b/public/dollhouse-org-security-red.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo security red variant">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#4f8ff7"></stop><stop offset="100%" stop-color="#2f6ddd"></stop></linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#2b5ec8"></stop><stop offset="100%" stop-color="#1f4caf"></stop></linearGradient>
+    <linearGradient id="chimneySecurityRed" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f87171"></stop><stop offset="100%" stop-color="#991b1b"></stop></linearGradient>
+  </defs>
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneySecurityRed)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#fca5a5" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#ef4444" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#dc2626" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#991b1b" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/dollhouse-org-tooling.svg
+++ b/public/dollhouse-org-tooling.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Dollhouse logo tooling variant">
+  <defs>
+    <linearGradient id="roofBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4f8ff7"></stop>
+      <stop offset="100%" stop-color="#2f6ddd"></stop>
+    </linearGradient>
+    <linearGradient id="baseBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b5ec8"></stop>
+      <stop offset="100%" stop-color="#1f4caf"></stop>
+    </linearGradient>
+    <linearGradient id="chimneyTooling" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4ade80"></stop>
+      <stop offset="100%" stop-color="#15803d"></stop>
+    </linearGradient>
+  </defs>
+
+  <rect x="23" y="16" width="9" height="15" rx="2" fill="url(#chimneyTooling)" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <path d="M50 10 L88 32 H12 Z" fill="url(#roofBlue)"></path>
+
+  <rect x="17" y="32" width="66" height="46" rx="4" fill="#4f8ff7"></rect>
+  <rect x="22" y="37" width="56" height="36" rx="4" fill="#ffffff"></rect>
+
+  <rect x="26" y="40" width="22" height="12" rx="3" fill="#86efac" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="40" width="22" height="12" rx="3" fill="#4ade80" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="26" y="56" width="22" height="12" rx="3" fill="#22c55e" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+  <rect x="52" y="56" width="22" height="12" rx="3" fill="#16a34a" stroke="#0a1020" stroke-width="1" stroke-opacity="0.4" vector-effect="non-scaling-stroke" paint-order="stroke fill"></rect>
+
+  <rect x="14" y="78" width="72" height="7" rx="3" fill="url(#baseBlue)"></rect>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -16,8 +16,13 @@
 
   <header class="site-header">
     <div class="header-brand">
-      <h1 class="site-title">DollhouseMCP Collection</h1>
-      <p class="site-tagline">Community AI elements for the Model Context Protocol</p>
+      <a class="brand-link" href="./" aria-label="DollhouseMCP Collection home">
+        <img class="brand-logo" src="dollhouse-org-collection-bluetop.svg" alt="" width="48" height="48" decoding="async" />
+      </a>
+      <div class="brand-text">
+        <h1 class="site-title">DollhouseMCP Collection</h1>
+        <p class="site-tagline">Community AI elements for the Model Context Protocol</p>
+      </div>
     </div>
     <div class="header-right">
       <div class="site-stats" id="stats" aria-live="polite"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -178,7 +178,13 @@ p, li { max-width: 69ch; }
   pointer-events: none;
 }
 
-.header-brand { display: flex; flex-direction: column; gap: 0.05rem; }
+.header-brand { display: flex; flex-direction: row; align-items: center; gap: 0.6rem; min-width: 0; }
+
+.brand-link { display: inline-flex; flex-shrink: 0; line-height: 0; }
+
+.brand-logo { width: 2.4rem; height: 2.4rem; display: block; }
+
+.brand-text { display: flex; flex-direction: column; gap: 0.05rem; min-width: 0; }
 
 .site-title {
   font-family: var(--font-heading);


### PR DESCRIPTION
## Summary

Brings the nine canonical DollhouseMCP design-system lane SVGs into `public/` and wires the Collection-lane mark into the site header. The Collection lane, per the locked-down design system, is **blue roof + blue walls, slate foundation, rainbow windows** — a catalog-tier sibling of the project lanes. Every SVG carries a baked-in 1px `non-scaling-stroke` at 0.4 opacity on the chimney + 4 windows.

## Changes

**Added** to `public/`:
- `dollhouse-org-brand.svg`
- `dollhouse-org-core.svg`
- `dollhouse-org-protocol.svg`
- `dollhouse-org-research.svg`
- `dollhouse-org-tooling.svg`
- `dollhouse-org-security-red.svg`
- `dollhouse-org-education-blocks.svg`
- `dollhouse-org-collection-bluetop.svg`
- `dollhouse-org-enterprise-corner.svg`

**`public/index.html`**: site header now renders `dollhouse-org-collection-bluetop.svg` at 48×48 beside the title, wrapped in a home-link anchor with `aria-label`. Title + tagline moved into a new `.brand-text` wrapper so the logo sits next to them without breaking layout.

**`public/styles.css`**: `.header-brand` flipped from column to row flex with `gap: 0.6rem`. New `.brand-link`, `.brand-logo`, `.brand-text` rules. The existing responsive hide rule (`.header-brand .site-tagline { display: none }` at ≤52rem) still matches — descendant selector — so the tagline still collapses on narrow viewports.

## Scope

Nine new SVGs, one header markup change, five small CSS additions. No changes to search, filter, card rendering, or any other UI surface.

Closes #283

## Test plan
- [ ] Serve `public/` locally; header renders Collection logo at 48×48 next to "DollhouseMCP Collection"
- [ ] Logo links to site root
- [ ] Toggle dark mode; logo outlines stay readable in both themes
- [ ] Narrow viewport (≤52rem): tagline hides, logo + title stay inline
- [ ] All 9 SVGs render cleanly at 24px / 100px / 320px when loaded directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)